### PR TITLE
Reduce radix tree memory footprint from ~90 to ~69 B/key

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,6 +104,17 @@ These four principles govern every design decision in the codebase, in priority 
 - Use `std::ssize` (C++20) instead of casting `.size()` to a signed type.
 - Prefer `std::filesystem` utilities over manual file-handle tricks (e.g. `std::filesystem::file_size`).
 
+### Safety through abstraction — compile-time first, runtime second
+
+Prefer designs where incorrect usage is impossible over designs where incorrect usage is merely caught. In priority order:
+
+1. **Compile-time safety**: Use the type system to make invalid states unrepresentable. If a capability or field is absent for a subset of instances, encode that in the types so that invalid access is a compiler error, not a runtime bug.
+2. **Runtime safety**: When compile-time enforcement is not possible (e.g. base-pointer dispatch), use assertions, tag checks, or safe defaults so that bugs produce crashes or wrong-but-safe behavior — never silent memory corruption or UB.
+
+Avoid designs where correctness depends on programmer discipline alone (e.g. "never touch field X on this variant"). A future contributor will forget. The abstraction should make forgetting either impossible (compile error) or immediately visible (assertion failure).
+
+**Example — the P4 Node/InternalNode split**: Rather than allocating leaf nodes at a smaller size and relying on discipline to never access the `children_` field (heap buffer overflow if violated), we split into `Node` (base, no `children_` field) and `InternalNode : Node` (derived, has `children_`). Accessing `children_` through a `Node*` is a compile error. Child accessor methods on `Node` check a tag bit before downcasting and return safe defaults ("no children") when the tag is absent.
+
 ### Iterator laziness — correctness requirement
 
 Iterators must fetch and process data lazily unless explicitly documented otherwise. An iterator that eagerly materializes all results into memory is a correctness bug: the result set may exceed available memory (e.g. a `changes_since` scan over millions of entries). The correct pattern is to hold at most one unit of work in memory at a time (one batch, one entry) and advance on demand.

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ ByteCaskDB is designed around four core tenets, in priority order:
   └── Sealed Files   read-only .data + .hint files      (older segments)
 ```
 
-**Write path**: all writes route through a single coordinator (`apply_batch`). Concurrent sync writers are batched via group commit — the first writer becomes leader, drains the queue, and executes all pending writes under one lock hold with a single `fdatasync`. Each write appends CRC-32-verified, length-prefixed records to the active data file, then applies pure in-memory state transitions via `TransientEngineState`. Durability before visibility: `state_.store()` happens after `fdatasync`.
+**Write path**: all writes route through a single coordinator (`apply_batch`). Concurrent sync writers are batched via group commit — the first writer becomes leader, drains the queue, and executes all pending writes under one lock hold with a single `fdatasync`. Each write appends CRC-32-verified, length-prefixed records to the active data file, then applies pure in-memory state transitions via `TransientEngineState`. The radix-tree builder used for those transitions is single-use: it freezes into the published immutable snapshot and fails fast on accidental reuse. Durability before visibility: `state_.store()` happens after `fdatasync`.
 
 **Read path**: readers obtain an immutable snapshot of the engine state, look up the key in the radix tree to find its file and offset, then read the value directly. Reads are lock-free and scale linearly across cores.
 

--- a/bytecaskdb-node/wasm/build.sh
+++ b/bytecaskdb-node/wasm/build.sh
@@ -110,12 +110,13 @@ precompile bytecask.data_file    bytecaskdb/data_file.cppm
 precompile bytecask.hint_file    bytecaskdb/hint_file.cppm
 precompile bytecask.batch_iterator bytecaskdb/batch_iterator.cppm
 precompile bytecask.concurrency  bytecaskdb/concurrency.cppm
+precompile bytecask.counters     bytecaskdb/counters.cppm
 precompile bytecask:internals    bytecaskdb/internals.cppm
 precompile bytecask              bytecaskdb/bytecask.cppm
 
 # ── Step 3: Compile object files ──────────────────────────────────────────────
 echo "=== Compiling objects ==="
-CPPM_FILES=(types util serialization data_entry hint_entry radix_tree u32_map data_file hint_file batch_iterator concurrency internals)
+CPPM_FILES=(types util serialization data_entry hint_entry radix_tree u32_map data_file hint_file batch_iterator concurrency counters internals)
 
 for f in "${CPPM_FILES[@]}"; do
   emcc $CFLAGS -c $MODS $CRC32C_INCLUDE "$ROOT/bytecaskdb/${f}.cppm" -o "$PCM/${f}.o"
@@ -158,6 +159,7 @@ testing_precompile bytecask.data_file    bytecaskdb/data_file.cppm
 testing_precompile bytecask.hint_file    bytecaskdb/hint_file.cppm
 testing_precompile bytecask.batch_iterator bytecaskdb/batch_iterator.cppm
 testing_precompile bytecask.concurrency  bytecaskdb/concurrency.cppm
+testing_precompile bytecask.counters     bytecaskdb/counters.cppm
 testing_precompile bytecask:internals    bytecaskdb/internals.cppm
 testing_precompile bytecask              bytecaskdb/bytecask.cppm
 

--- a/bytecaskdb-node/wasm/bytecask_embind.cpp
+++ b/bytecaskdb-node/wasm/bytecask_embind.cpp
@@ -590,6 +590,15 @@ static void js_file_manifest_close(JsFileManifest &self) {
   // snapshot is owned separately, caller must close it.
   delete &self;
 }
+static auto js_file_manifest_get_snapshot(JsFileManifest &self) -> JsSnapshot * {
+  return self.snapshot;
+}
+static auto js_file_manifest_get_files(JsFileManifest &self) -> val {
+  return self.files;
+}
+static auto js_file_manifest_get_through_sequence(JsFileManifest &self) -> double {
+  return self.through_sequence;
+}
 
 // ---------------------------------------------------------------------------
 // Embind registration
@@ -664,14 +673,8 @@ EMSCRIPTEN_BINDINGS(bytecask) {
       .function("close", &js_change_iter_close);
 
   class_<JsFileManifest>("FileManifest")
-      .function("getSnapshot", [](JsFileManifest &self) -> JsSnapshot * {
-        return self.snapshot;
-      }, allow_raw_pointers())
-      .function("getFiles", [](JsFileManifest &self) -> val {
-        return self.files;
-      })
-      .function("getThroughSequence", [](JsFileManifest &self) -> double {
-        return self.through_sequence;
-      })
+      .function("getSnapshot", &js_file_manifest_get_snapshot, allow_raw_pointers())
+      .function("getFiles", &js_file_manifest_get_files)
+      .function("getThroughSequence", &js_file_manifest_get_through_sequence)
       .function("close", &js_file_manifest_close);
 }

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -15,6 +15,7 @@ module;
 #include <new>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -296,33 +297,56 @@ template <typename V> struct Node {
   }
   void clear_value() noexcept { packed_tag_ &= ~kHasValueBit; }
 
+  [[nodiscard]] auto internal_node() noexcept -> InternalNode<V> * {
+    if (!has_children_flag())
+      return nullptr;
+    return static_cast<InternalNode<V> *>(this);
+  }
+  [[nodiscard]] auto internal_node() const noexcept
+      -> const InternalNode<V> * {
+    if (!has_children_flag())
+      return nullptr;
+    return static_cast<const InternalNode<V> *>(this);
+  }
+  [[nodiscard]] auto child_store_or_null() noexcept -> ChildStore * {
+    auto *internal = internal_node();
+    if (!internal)
+      return nullptr;
+    return internal->children_.get();
+  }
+  [[nodiscard]] auto child_store_or_null() const noexcept
+      -> const ChildStore * {
+    auto *internal = internal_node();
+    if (!internal)
+      return nullptr;
+    return internal->children_.get();
+  }
+
   // -- Children accessors (delegate to InternalNode via checked cast) -------
   [[nodiscard]] auto child_count() const noexcept -> std::size_t {
-    if (!has_children_flag()) return 0;
-    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
     return kids ? kids->size() : 0;
   }
   [[nodiscard]] auto has_children() const noexcept -> bool {
-    if (!has_children_flag()) return false;
-    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
     return kids && !kids->empty();
   }
   [[nodiscard]] auto child_at(std::size_t i) const -> ConstChildRef {
-    assert(has_children_flag());
-    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
+    assert(kids != nullptr);
+    assert(i < kids->size());
     return {kids->transition_bytes[i], kids->ptrs[i]};
   }
   [[nodiscard]] auto child_at(std::size_t i) -> ChildRef {
-    assert(has_children_flag());
-    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
+    assert(kids != nullptr);
+    assert(i < kids->size());
     return {kids->transition_bytes[i], kids->ptrs[i]};
   }
 
   [[nodiscard]] auto find_child(std::byte b) const
       -> std::optional<ConstChildRef> {
-    if (!has_children_flag())
-      return std::nullopt;
-    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
     if (!kids)
       return std::nullopt;
     for (std::size_t i = 0; i < kids->size(); ++i) {
@@ -333,9 +357,7 @@ template <typename V> struct Node {
   }
 
   [[nodiscard]] auto find_child_mut(std::byte b) -> std::optional<ChildRef> {
-    if (!has_children_flag())
-      return std::nullopt;
-    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
     if (!kids)
       return std::nullopt;
     for (std::size_t i = 0; i < kids->size(); ++i) {
@@ -346,28 +368,27 @@ template <typename V> struct Node {
   }
 
   void insert_child(std::byte b, IntrusivePtr<Node> child) {
-    assert(has_children_flag());
-    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
-    if (!kids)
-      kids = std::make_unique<ChildStore>();
+    auto *internal = internal_node();
+    assert(internal != nullptr);
+    if (!internal->children_)
+      internal->children_ = std::make_unique<ChildStore>();
+    auto &kids = *internal->children_;
     std::size_t pos = 0;
-    while (pos < kids->size() && kids->transition_bytes[pos] < b)
+    while (pos < kids.size() && kids.transition_bytes[pos] < b)
       ++pos;
-    assert((pos == kids->size() || kids->transition_bytes[pos] != b) &&
+    assert((pos == kids.size() || kids.transition_bytes[pos] != b) &&
            "duplicate transition byte");
-    kids->transition_bytes.insert(
-        kids->transition_bytes.begin() +
+    kids.transition_bytes.insert(
+      kids.transition_bytes.begin() +
             static_cast<std::ptrdiff_t>(pos),
         b);
-    kids->ptrs.insert(
-        kids->ptrs.begin() + static_cast<std::ptrdiff_t>(pos),
+    kids.ptrs.insert(
+      kids.ptrs.begin() + static_cast<std::ptrdiff_t>(pos),
         std::move(child));
   }
 
   void remove_child(std::byte b) {
-    if (!has_children_flag())
-      return;
-    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    auto *kids = child_store_or_null();
     if (!kids)
       return;
     for (std::size_t i = 0; i < kids->size(); ++i) {
@@ -385,7 +406,8 @@ template <typename V> struct Node {
   // Deep clone of this node (not recursive — children are shared).
   [[nodiscard]] auto clone() const -> IntrusivePtr<Node> {
     if (has_children_flag()) {
-      auto* self = static_cast<const InternalNode<V>*>(this);
+      auto *self = internal_node();
+      assert(self != nullptr);
       auto* n = new InternalNode<V>();
       n->packed_tag_ = packed_tag_ & kFlagBits;
       n->value_ = value_;
@@ -416,7 +438,7 @@ template <typename V> struct Node {
     n->value_ = value_;
     n->prefix = prefix;
     if (has_children_flag()) {
-      auto& src = static_cast<const InternalNode<V>*>(this)->children_;
+      auto *src = child_store_or_null();
       if (src)
         n->children_ = std::make_unique<ChildStore>(*src);
     }
@@ -1047,13 +1069,15 @@ public:
 
   [[nodiscard]] auto get(std::span<const std::byte> key) const
       -> std::optional<V> {
+    ensure_active();
     if (!root_)
       return std::nullopt;
     return PersistentRadixTree<V>::get_impl(root_, key);
   }
 
-  [[nodiscard]] auto get_ptr(std::span<const std::byte> key) const noexcept
+  [[nodiscard]] auto get_ptr(std::span<const std::byte> key) const
       -> const V * {
+    ensure_active();
     if (!root_)
       return nullptr;
     return PersistentRadixTree<V>::get_ptr_impl(root_, key);
@@ -1064,7 +1088,7 @@ public:
   }
 
   void set(std::span<const std::byte> key, V val) {
-    assert(tag_ != 0 && "transient already consumed");
+    ensure_active();
     auto [new_root, inserted] = set_transient(root_, key, std::move(val), tag_);
     root_ = std::move(new_root);
     if (inserted)
@@ -1079,7 +1103,7 @@ public:
   template <typename Pred>
   auto upsert(std::span<const std::byte> key, V val, Pred &&should_replace)
       -> std::optional<V> {
-    assert(tag_ != 0 && "transient already consumed");
+    ensure_active();
     auto [new_root, displaced, inserted] = upsert_transient(
         root_, key, std::move(val), tag_,
         std::forward<Pred>(should_replace));
@@ -1090,7 +1114,7 @@ public:
   }
 
   auto erase(std::span<const std::byte> key) -> bool {
-    assert(tag_ != 0 && "transient already consumed");
+    ensure_active();
     if (!root_)
       return false;
     auto [new_root, removed] = erase_transient(root_, key, tag_);
@@ -1101,14 +1125,17 @@ public:
   }
 
   [[nodiscard]] auto persistent() && -> PersistentRadixTree<V> {
+    ensure_active();
+    auto live_size = std::exchange(size_, 0);
     tag_ = 0; // Retire the tag — nodes become immutable.
-    return PersistentRadixTree<V>{std::move(root_), size_};
+    return PersistentRadixTree<V>{std::move(root_), live_size};
   }
 
   // Iteration support for range scans on the transient tree.
   // Shares the same internal structure as PersistentRadixTree.
   [[nodiscard]] auto lower_bound(std::span<const std::byte> key) const
       -> RadixTreeIterator<V> {
+    ensure_active();
     return RadixTreeIterator<V>{root_, key};
   }
 
@@ -1120,6 +1147,12 @@ private:
   TransientRadixTree(IntrusivePtr<Node<V>> root, std::size_t sz,
                      std::uint32_t tag)
       : root_{std::move(root)}, size_{sz}, tag_{tag} {}
+
+  void ensure_active() const {
+    if (tag_ == 0) [[unlikely]] {
+      throw std::logic_error{"TransientRadixTree already consumed"};
+    }
+  }
 
   // Ensure a node is owned by this transient session.
   // Requires both matching edit tag AND unique ownership (refcount == 1)

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -183,30 +183,38 @@ inline std::atomic<std::uint64_t> next_edit_tag{1};
 } // namespace detail
 
 // ---------------------------------------------------------------------------
-// Node<V>
+// Node<V> — base type for all radix tree nodes (leaf and internal).
+//
+// packed_tag_ bit layout:
+//   [31: has_value] [30: has_children] [29:0: edit_tag]
+//
+// 94% of nodes are leaves that never acquire children. By splitting the
+// children_ field into a derived InternalNode<V>, leaf nodes are allocated
+// at sizeof(Node) = 40 bytes (glibc usable=40) instead of 48 bytes
+// (glibc usable=56), saving 16 bytes per leaf.
+//
+// Safety: children_ does not exist on Node — accessing it through a Node*
+// is a compile error. Child accessor methods check has_children_flag()
+// before downcasting to InternalNode; a missing flag returns a safe default
+// ("no children"), never memory corruption.
 // ---------------------------------------------------------------------------
+template <typename V> struct InternalNode; // forward declaration
+
 template <typename V> struct Node {
-  // Intrusive reference count. mutable so addref/release work through const
-  // paths (same semantics as shared_ptr's control block).
-  // Starts at 1: make_intrusive + IntrusivePtr::adopt() take ownership
-  // without incrementing.
   mutable std::atomic<std::uint32_t> refcount_{1};
 
-  // High bit of packed_tag_ = 1 means this node holds a value.
-  // Low 31 bits = transient edit tag (0 = immutable).
+  static constexpr std::uint32_t kHasValueBit = 0x8000'0000u;
+  static constexpr std::uint32_t kHasChildrenBit = 0x4000'0000u;
+  static constexpr std::uint32_t kFlagBits = kHasValueBit | kHasChildrenBit;
+  static constexpr std::uint32_t kTagMask = 0x3FFF'FFFFu;
+
   std::uint32_t packed_tag_{0};
   V value_{};
 
   using Prefix = CompactPrefix;
   Prefix prefix;
 
-  // Children: null for leaf nodes, heap-allocated for internal nodes.
-  // 94% of nodes are leaves — they pay only 8 B (null pointer) instead
-  // of embedding an empty vector in the node.
-  //
-  // SoA layout: parallel vectors of transition bytes and child pointers.
-  // Eliminates 7 bytes of alignment padding per slot that
-  // pair<byte, IntrusivePtr<Node>> would waste (1 + 7 pad + 8 = 16 → 1 + 8 = 9).
+  // -- Child nested types (used by InternalNode, exposed here for callers) --
   struct ChildRef {
     std::byte &transition;
     IntrusivePtr<Node> &ptr;
@@ -225,7 +233,6 @@ template <typename V> struct Node {
       return transition_bytes.empty();
     }
   };
-  std::unique_ptr<ChildStore> children_;
 
   void addref() const noexcept {
     refcount_.fetch_add(1, std::memory_order_relaxed);
@@ -240,22 +247,22 @@ template <typename V> struct Node {
   // the dominant pattern in compressed radix trees.
   void release() const noexcept {
     const Node* cur = this;
-    // acq_rel on every fetch_sub: ensures all prior writes to the
-    // node are visible before the deleting thread runs the destructor.
     while (cur->refcount_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      // Sole owner — safe to const_cast and detach children before
-      // deleting, so ~Node doesn't trigger recursive releases.
       auto* mut = const_cast<Node*>(cur);
-      auto kids = std::move(mut->children_);
-      delete mut;
+      bool has_kids = mut->has_children_flag();
+
+      std::unique_ptr<ChildStore> kids;
+      if (has_kids) {
+        auto* internal = static_cast<InternalNode<V>*>(mut);
+        kids = std::move(internal->children_);
+        delete internal;
+      } else {
+        delete mut;
+      }
 
       if (!kids || kids->empty())
         return;
 
-      // Detach every child from its IntrusivePtr (no refcount change)
-      // and release all but the last one recursively. The last child
-      // becomes the next iteration's cur, converting tail recursion
-      // into a loop.
       const Node* tail = nullptr;
       for (std::size_t i = 0; i < kids->size(); ++i) {
         auto* raw = kids->ptrs[i].detach();
@@ -268,91 +275,107 @@ template <typename V> struct Node {
       if (!tail)
         return;
       cur = tail;
-      // Loop restarts: fetch_sub on tail's refcount acts as release.
     }
   }
 
   [[nodiscard]] auto has_value() const noexcept -> bool {
-    return (packed_tag_ >> 31) != 0;
+    return (packed_tag_ & kHasValueBit) != 0;
+  }
+  [[nodiscard]] auto has_children_flag() const noexcept -> bool {
+    return (packed_tag_ & kHasChildrenBit) != 0;
   }
   [[nodiscard]] auto edit_tag() const noexcept -> std::uint32_t {
-    return packed_tag_ & 0x7FFF'FFFFu;
+    return packed_tag_ & kTagMask;
   }
   void set_edit_tag(std::uint32_t tag) noexcept {
-    packed_tag_ = (packed_tag_ & 0x8000'0000u) | (tag & 0x7FFF'FFFFu);
+    packed_tag_ = (packed_tag_ & kFlagBits) | (tag & kTagMask);
   }
   void set_value(V v) {
     value_ = std::move(v);
-    packed_tag_ |= 0x8000'0000u;
+    packed_tag_ |= kHasValueBit;
   }
-  void clear_value() noexcept { packed_tag_ &= 0x7FFF'FFFFu; }
+  void clear_value() noexcept { packed_tag_ &= ~kHasValueBit; }
 
-  // -- Children accessors ---------------------------------------------------
+  // -- Children accessors (delegate to InternalNode via checked cast) -------
   [[nodiscard]] auto child_count() const noexcept -> std::size_t {
-    return children_ ? children_->size() : 0;
+    if (!has_children_flag()) return 0;
+    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    return kids ? kids->size() : 0;
   }
   [[nodiscard]] auto has_children() const noexcept -> bool {
-    return children_ && !children_->empty();
+    if (!has_children_flag()) return false;
+    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    return kids && !kids->empty();
   }
   [[nodiscard]] auto child_at(std::size_t i) const -> ConstChildRef {
-    return {children_->transition_bytes[i], children_->ptrs[i]};
+    assert(has_children_flag());
+    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    return {kids->transition_bytes[i], kids->ptrs[i]};
   }
   [[nodiscard]] auto child_at(std::size_t i) -> ChildRef {
-    return {children_->transition_bytes[i], children_->ptrs[i]};
+    assert(has_children_flag());
+    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    return {kids->transition_bytes[i], kids->ptrs[i]};
   }
 
-  // Find child by transition byte. Children are sorted by transition byte.
-  // Linear scan is used because prefix compression keeps child counts small
-  // (typically 1–4), where it outperforms binary search.
   [[nodiscard]] auto find_child(std::byte b) const
       -> std::optional<ConstChildRef> {
-    if (!children_)
+    if (!has_children_flag())
       return std::nullopt;
-    for (std::size_t i = 0; i < children_->size(); ++i) {
-      if (children_->transition_bytes[i] == b)
-        return ConstChildRef{children_->transition_bytes[i],
-                             children_->ptrs[i]};
+    auto& kids = static_cast<const InternalNode<V>*>(this)->children_;
+    if (!kids)
+      return std::nullopt;
+    for (std::size_t i = 0; i < kids->size(); ++i) {
+      if (kids->transition_bytes[i] == b)
+        return ConstChildRef{kids->transition_bytes[i], kids->ptrs[i]};
     }
     return std::nullopt;
   }
 
   [[nodiscard]] auto find_child_mut(std::byte b) -> std::optional<ChildRef> {
-    if (!children_)
+    if (!has_children_flag())
       return std::nullopt;
-    for (std::size_t i = 0; i < children_->size(); ++i) {
-      if (children_->transition_bytes[i] == b)
-        return ChildRef{children_->transition_bytes[i], children_->ptrs[i]};
+    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    if (!kids)
+      return std::nullopt;
+    for (std::size_t i = 0; i < kids->size(); ++i) {
+      if (kids->transition_bytes[i] == b)
+        return ChildRef{kids->transition_bytes[i], kids->ptrs[i]};
     }
     return std::nullopt;
   }
 
-  // Insert child in sorted order by transition byte.
   void insert_child(std::byte b, IntrusivePtr<Node> child) {
-    if (!children_)
-      children_ = std::make_unique<ChildStore>();
+    assert(has_children_flag());
+    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    if (!kids)
+      kids = std::make_unique<ChildStore>();
     std::size_t pos = 0;
-    while (pos < children_->size() && children_->transition_bytes[pos] < b)
+    while (pos < kids->size() && kids->transition_bytes[pos] < b)
       ++pos;
-    assert((pos == children_->size() || children_->transition_bytes[pos] != b) &&
+    assert((pos == kids->size() || kids->transition_bytes[pos] != b) &&
            "duplicate transition byte");
-    children_->transition_bytes.insert(
-        children_->transition_bytes.begin() +
+    kids->transition_bytes.insert(
+        kids->transition_bytes.begin() +
             static_cast<std::ptrdiff_t>(pos),
         b);
-    children_->ptrs.insert(
-        children_->ptrs.begin() + static_cast<std::ptrdiff_t>(pos),
+    kids->ptrs.insert(
+        kids->ptrs.begin() + static_cast<std::ptrdiff_t>(pos),
         std::move(child));
   }
 
   void remove_child(std::byte b) {
-    if (!children_)
+    if (!has_children_flag())
       return;
-    for (std::size_t i = 0; i < children_->size(); ++i) {
-      if (children_->transition_bytes[i] == b) {
-        children_->transition_bytes.erase(
-            children_->transition_bytes.begin() +
+    auto& kids = static_cast<InternalNode<V>*>(this)->children_;
+    if (!kids)
+      return;
+    for (std::size_t i = 0; i < kids->size(); ++i) {
+      if (kids->transition_bytes[i] == b) {
+        kids->transition_bytes.erase(
+            kids->transition_bytes.begin() +
                 static_cast<std::ptrdiff_t>(i));
-        children_->ptrs.erase(children_->ptrs.begin() +
+        kids->ptrs.erase(kids->ptrs.begin() +
                               static_cast<std::ptrdiff_t>(i));
         return;
       }
@@ -361,14 +384,21 @@ template <typename V> struct Node {
 
   // Deep clone of this node (not recursive — children are shared).
   [[nodiscard]] auto clone() const -> IntrusivePtr<Node> {
-    auto n = make_intrusive<Node>();
-    // Clear edit_tag in the clone; preserve has_value bit.
-    n->packed_tag_ = packed_tag_ & 0x8000'0000u;
+    if (has_children_flag()) {
+      auto* self = static_cast<const InternalNode<V>*>(this);
+      auto* n = new InternalNode<V>();
+      n->packed_tag_ = packed_tag_ & kFlagBits;
+      n->value_ = value_;
+      n->prefix = prefix;
+      if (self->children_)
+        n->children_ = std::make_unique<ChildStore>(*self->children_);
+      return IntrusivePtr<Node>::adopt(n);
+    }
+    auto* n = new Node();
+    n->packed_tag_ = packed_tag_ & kHasValueBit;
     n->value_ = value_;
     n->prefix = prefix;
-    if (children_)
-      n->children_ = std::make_unique<ChildStore>(*children_);
-    return n;
+    return IntrusivePtr<Node>::adopt(n);
   }
 
   // Clone and stamp with edit tag for transient ownership.
@@ -377,11 +407,69 @@ template <typename V> struct Node {
     n->set_edit_tag(tag);
     return n;
   }
+
+  // Clone, promoting to InternalNode if this is a leaf.
+  // Used when the caller will insert children into the clone.
+  [[nodiscard]] auto clone_as_internal() const -> IntrusivePtr<Node> {
+    auto* n = new InternalNode<V>();
+    n->packed_tag_ = (packed_tag_ & kHasValueBit) | kHasChildrenBit;
+    n->value_ = value_;
+    n->prefix = prefix;
+    if (has_children_flag()) {
+      auto& src = static_cast<const InternalNode<V>*>(this)->children_;
+      if (src)
+        n->children_ = std::make_unique<ChildStore>(*src);
+    }
+    return IntrusivePtr<Node>::adopt(n);
+  }
 };
 
-// Check Node size after CompactPrefix shrink (16B → 8B).
-// Node<uint64_t>: 4+4+8+8+8 = 32.
-static_assert(sizeof(Node<std::uint64_t>) == 32);
+// ---------------------------------------------------------------------------
+// InternalNode<V> — extends Node with children storage.
+//
+// Allocated only for nodes that will have children (routing/split nodes).
+// sizeof(InternalNode<KeyDirEntry>) == 48, glibc usable=56.
+// ---------------------------------------------------------------------------
+template <typename V> struct InternalNode : Node<V> {
+  std::unique_ptr<typename Node<V>::ChildStore> children_;
+};
+
+// Node<uint64_t>: 4+4+8+8 = 24 (no children_ field).
+static_assert(sizeof(Node<std::uint64_t>) == 24);
+// InternalNode<uint64_t>: 24+8 = 32.
+static_assert(sizeof(InternalNode<std::uint64_t>) == 32);
+
+// Factory functions for node allocation.
+// make_leaf: allocates Node (40B for KeyDirEntry), no children.
+// make_internal: allocates InternalNode (48B for KeyDirEntry), with
+// has_children flag set.
+template <typename V>
+auto make_leaf() -> IntrusivePtr<Node<V>> {
+  return IntrusivePtr<Node<V>>::adopt(new Node<V>());
+}
+
+template <typename V>
+auto make_internal() -> IntrusivePtr<Node<V>> {
+  auto* n = new InternalNode<V>();
+  n->packed_tag_ |= Node<V>::kHasChildrenBit;
+  return IntrusivePtr<Node<V>>::adopt(n);
+}
+
+// Promote a leaf node to internal. Returns a new InternalNode with the
+// same fields (value, prefix, edit_tag) plus has_children set.
+// The original node is not modified — callers replace their pointer.
+template <typename V>
+auto promote_to_internal(const IntrusivePtr<Node<V>> &node)
+    -> IntrusivePtr<Node<V>> {
+  assert(!node->has_children_flag());
+  auto* n = new InternalNode<V>();
+  n->packed_tag_ = (node->packed_tag_ & ~Node<V>::kFlagBits) |
+                   (node->packed_tag_ & Node<V>::kHasValueBit) |
+                   Node<V>::kHasChildrenBit;
+  n->value_ = node->value_;
+  n->prefix = node->prefix;
+  return IntrusivePtr<Node<V>>::adopt(n);
+}
 
 // ---------------------------------------------------------------------------
 // Helper: compute the common prefix length between a node's prefix and a key
@@ -542,7 +630,7 @@ private:
       -> IntrusivePtr<Node<V>> {
     // Fast path: key fits in a single node's prefix.
     if (key.size() <= CompactPrefix::kInlineCap) {
-      auto leaf = make_intrusive<Node<V>>();
+      auto leaf = make_leaf<V>();
       if (tag)
         leaf->set_edit_tag(tag);
       for (auto b : key)
@@ -568,7 +656,7 @@ private:
     auto leaf_prefix = key.subspan(pos);
 
     // Build bottom-up: leaf first, then wrap in routing nodes.
-    auto cur = make_intrusive<Node<V>>();
+    auto cur = make_leaf<V>();
     if (tag)
       cur->set_edit_tag(tag);
     for (auto b : leaf_prefix)
@@ -576,7 +664,7 @@ private:
     cur->set_value(std::move(val));
 
     for (auto it = chunks.rbegin(); it != chunks.rend(); ++it) {
-      auto routing = make_intrusive<Node<V>>();
+      auto routing = make_internal<V>();
       if (tag)
         routing->set_edit_tag(tag);
       for (std::size_t i = 0; i < it->prefix_len; ++i)
@@ -623,7 +711,7 @@ private:
     // Build bottom-up: terminal is the innermost node.
     auto cur = std::move(terminal);
     for (auto it = chunks.rbegin(); it != chunks.rend(); ++it) {
-      auto routing = make_intrusive<Node<V>>();
+      auto routing = make_internal<V>();
       if (tag)
         routing->set_edit_tag(tag);
       for (std::size_t i = 0; i < it->prefix_len; ++i)
@@ -650,8 +738,7 @@ private:
 
     if (cpl < prefix_span.size()) {
       // Split: divergence within this node's prefix.
-      auto split = make_intrusive<Node<V>>();
-      // Split node gets the common prefix.
+      auto split = make_internal<V>();
       for (std::size_t i = 0; i < cpl; ++i)
         split->prefix.push_back(prefix_span[i]);
 
@@ -698,7 +785,11 @@ private:
       return {std::move(new_node), inserted};
     }
     // No child for this transition — create a leaf.
+    // Promote to internal if the clone is a leaf (the node previously
+    // had no children but now needs one).
     auto chain = build_leaf_chain(child_key, std::move(val));
+    if (!new_node->has_children_flag())
+      new_node = promote_to_internal(new_node);
     new_node->insert_child(transition, std::move(chain));
     return {std::move(new_node), true};
   }
@@ -831,7 +922,7 @@ private:
     if (cpl < pa.size() && cpl < pb.size()) {
       // The two prefixes diverge — build a split node with the common prefix,
       // then place trimmed a and trimmed b as its two children.
-      auto split = make_intrusive<Node<V>>();
+      auto split = make_internal<V>();
       for (std::size_t i = 0; i < cpl; ++i)
         split->prefix.push_back(pa[i]);
 
@@ -855,7 +946,7 @@ private:
     if (cpl < pa.size()) {
       // b's prefix is fully consumed — b's node sits *above* a in the trie.
       // Build result based on b; insert a under b at transition pa[cpl].
-      auto new_b = b->clone();
+      auto new_b = b->clone_as_internal();
       auto a_trimmed = a->clone();
       typename Node<V>::Prefix a_suffix;
       for (std::size_t i = cpl + 1; i < pa.size(); ++i)
@@ -878,7 +969,7 @@ private:
     if (cpl < pb.size()) {
       // a's prefix is fully consumed — a's node sits *above* b in the trie.
       // Build result based on a; insert b under a at transition pb[cpl].
-      auto new_a = a->clone();
+      auto new_a = a->clone_as_internal();
       auto b_trimmed = b->clone();
       typename Node<V>::Prefix b_suffix;
       for (std::size_t i = cpl + 1; i < pb.size(); ++i)
@@ -899,8 +990,8 @@ private:
     }
 
     // Full prefix match — both nodes share the same compressed key prefix.
-    // Clone a and fold b's value + children into it.
-    auto merged = a->clone();
+    // Clone a as internal — b's children may need to be folded in.
+    auto merged = a->clone_as_internal();
     std::size_t overlaps = 0;
 
     if (b->has_value()) {
@@ -1043,7 +1134,7 @@ private:
         node->refcount_.load(std::memory_order_acquire) == 1)
       return node;
     if (!node) {
-      auto n = make_intrusive<Node<V>>();
+      auto n = make_leaf<V>();
       n->set_edit_tag(tag);
       return n;
     }
@@ -1066,7 +1157,7 @@ private:
 
     if (cpl < prefix_span.size()) {
       // Split.
-      auto split = make_intrusive<Node<V>>();
+      auto split = make_internal<V>();
       split->set_edit_tag(tag);
       for (std::size_t i = 0; i < cpl; ++i)
         split->prefix.push_back(prefix_span[i]);
@@ -1106,6 +1197,8 @@ private:
       return {std::move(mutable_node), inserted};
     }
     auto chain = Ops::build_leaf_chain(child_key, std::move(val), tag);
+    if (!mutable_node->has_children_flag())
+      mutable_node = promote_to_internal(mutable_node);
     mutable_node->insert_child(transition, std::move(chain));
     return {std::move(mutable_node), true};
   }
@@ -1130,7 +1223,7 @@ private:
 
     if (cpl < prefix_span.size()) {
       // Split — key diverges from prefix, so this is always a new insert.
-      auto split = make_intrusive<Node<V>>();
+      auto split = make_internal<V>();
       split->set_edit_tag(tag);
       for (std::size_t i = 0; i < cpl; ++i)
         split->prefix.push_back(prefix_span[i]);
@@ -1178,6 +1271,8 @@ private:
       return {std::move(mutable_node), std::move(displaced), inserted};
     }
     auto chain = Ops::build_leaf_chain(child_key, std::move(val), tag);
+    if (!mutable_node->has_children_flag())
+      mutable_node = promote_to_internal(mutable_node);
     mutable_node->insert_child(transition, std::move(chain));
     return {std::move(mutable_node), std::nullopt, true};
   }
@@ -1293,13 +1388,14 @@ template <typename V>
 auto PersistentRadixTree<V>::transient() const -> TransientRadixTree<V> {
   // Relaxed ordering: only uniqueness is required, not inter-thread visibility
   // ordering. Each transient session gets a distinct tag via fetch_add.
-  // Truncate to 31 bits — tag 0 is reserved for "immutable" sentinel.
+  // Truncate to 30 bits — tag 0 is reserved for "immutable" sentinel.
+  // Bit 31 = has_value, bit 30 = has_children, bits 29:0 = edit_tag.
   auto raw = detail::next_edit_tag.fetch_add(1, std::memory_order_relaxed);
-  auto tag = static_cast<std::uint32_t>(raw & 0x7FFF'FFFFu);
+  auto tag = static_cast<std::uint32_t>(raw & Node<V>::kTagMask);
   if (tag == 0) [[unlikely]]
     tag = static_cast<std::uint32_t>(
         detail::next_edit_tag.fetch_add(1, std::memory_order_relaxed) &
-        0x7FFF'FFFFu);
+        Node<V>::kTagMask);
   return TransientRadixTree<V>{root_, size_, tag};
 }
 

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -319,16 +319,36 @@ template <typename V> struct Node {
   // Children: null for leaf nodes, heap-allocated for internal nodes.
   // 94% of nodes are leaves — they pay only 8 B (null pointer) instead
   // of embedding an empty vector in the node.
-  using ChildSlot = std::pair<std::byte, IntrusivePtr<Node>>;
-  using ChildVec = std::vector<ChildSlot>;
-  std::unique_ptr<ChildVec> children_;
+  //
+  // SoA layout: parallel vectors of transition bytes and child pointers.
+  // Eliminates 7 bytes of alignment padding per slot that
+  // pair<byte, IntrusivePtr<Node>> would waste (1 + 7 pad + 8 = 16 → 1 + 8 = 9).
+  struct ChildRef {
+    std::byte &transition;
+    IntrusivePtr<Node> &ptr;
+  };
+  struct ConstChildRef {
+    const std::byte &transition;
+    const IntrusivePtr<Node> &ptr;
+  };
+  struct ChildStore {
+    std::vector<std::byte> transition_bytes;
+    std::vector<IntrusivePtr<Node>> ptrs;
+    [[nodiscard]] auto size() const noexcept -> std::size_t {
+      return transition_bytes.size();
+    }
+    [[nodiscard]] auto empty() const noexcept -> bool {
+      return transition_bytes.empty();
+    }
+  };
+  std::unique_ptr<ChildStore> children_;
 
   void addref() const noexcept {
     refcount_.fetch_add(1, std::memory_order_relaxed);
   }
   // Iterative tail-release avoids the O(depth) recursive destructor chain
   // that otherwise occurs via ~IntrusivePtr → release → delete → ~Node →
-  // ~ChildVec → ~IntrusivePtr → … .
+  // ~ChildStore → ~IntrusivePtr → … .
   //
   // Profiling (perf record, MergeOverlapping/100K) showed this cascade as
   // 29% of total merge time. Converting the last-child release to a loop
@@ -353,8 +373,8 @@ template <typename V> struct Node {
       // becomes the next iteration's cur, converting tail recursion
       // into a loop.
       const Node* tail = nullptr;
-      for (auto& [b, child_ptr] : *kids) {
-        auto* raw = child_ptr.detach();
+      for (std::size_t i = 0; i < kids->size(); ++i) {
+        auto* raw = kids->ptrs[i].detach();
         if (!raw) continue;
         if (tail)
           tail->release();
@@ -390,54 +410,66 @@ template <typename V> struct Node {
   [[nodiscard]] auto has_children() const noexcept -> bool {
     return children_ && !children_->empty();
   }
-  [[nodiscard]] auto child_at(std::size_t i) const -> const ChildSlot & {
-    return (*children_)[i];
+  [[nodiscard]] auto child_at(std::size_t i) const -> ConstChildRef {
+    return {children_->transition_bytes[i], children_->ptrs[i]};
   }
-  [[nodiscard]] auto child_at(std::size_t i) -> ChildSlot & {
-    return (*children_)[i];
+  [[nodiscard]] auto child_at(std::size_t i) -> ChildRef {
+    return {children_->transition_bytes[i], children_->ptrs[i]};
   }
 
   // Find child by transition byte. Children are sorted by transition byte.
   // Linear scan is used because prefix compression keeps child counts small
   // (typically 1–4), where it outperforms binary search.
-  [[nodiscard]] auto find_child(std::byte b) const -> const ChildSlot * {
+  [[nodiscard]] auto find_child(std::byte b) const
+      -> std::optional<ConstChildRef> {
     if (!children_)
-      return nullptr;
-    for (auto &c : *children_) {
-      if (c.first == b)
-        return &c;
+      return std::nullopt;
+    for (std::size_t i = 0; i < children_->size(); ++i) {
+      if (children_->transition_bytes[i] == b)
+        return ConstChildRef{children_->transition_bytes[i],
+                             children_->ptrs[i]};
     }
-    return nullptr;
+    return std::nullopt;
   }
 
-  [[nodiscard]] auto find_child_mut(std::byte b) -> ChildSlot * {
+  [[nodiscard]] auto find_child_mut(std::byte b) -> std::optional<ChildRef> {
     if (!children_)
-      return nullptr;
-    for (auto &c : *children_) {
-      if (c.first == b)
-        return &c;
+      return std::nullopt;
+    for (std::size_t i = 0; i < children_->size(); ++i) {
+      if (children_->transition_bytes[i] == b)
+        return ChildRef{children_->transition_bytes[i], children_->ptrs[i]};
     }
-    return nullptr;
+    return std::nullopt;
   }
 
   // Insert child in sorted order by transition byte.
   void insert_child(std::byte b, IntrusivePtr<Node> child) {
     if (!children_)
-      children_ = std::make_unique<ChildVec>();
-    auto it = children_->begin();
-    while (it != children_->end() && it->first < b)
-      ++it;
-    assert((it == children_->end() || it->first != b) &&
+      children_ = std::make_unique<ChildStore>();
+    std::size_t pos = 0;
+    while (pos < children_->size() && children_->transition_bytes[pos] < b)
+      ++pos;
+    assert((pos == children_->size() || children_->transition_bytes[pos] != b) &&
            "duplicate transition byte");
-    children_->insert(it, {b, std::move(child)});
+    children_->transition_bytes.insert(
+        children_->transition_bytes.begin() +
+            static_cast<std::ptrdiff_t>(pos),
+        b);
+    children_->ptrs.insert(
+        children_->ptrs.begin() + static_cast<std::ptrdiff_t>(pos),
+        std::move(child));
   }
 
   void remove_child(std::byte b) {
     if (!children_)
       return;
-    for (auto it = children_->begin(); it != children_->end(); ++it) {
-      if (it->first == b) {
-        children_->erase(it);
+    for (std::size_t i = 0; i < children_->size(); ++i) {
+      if (children_->transition_bytes[i] == b) {
+        children_->transition_bytes.erase(
+            children_->transition_bytes.begin() +
+                static_cast<std::ptrdiff_t>(i));
+        children_->ptrs.erase(children_->ptrs.begin() +
+                              static_cast<std::ptrdiff_t>(i));
         return;
       }
     }
@@ -451,7 +483,7 @@ template <typename V> struct Node {
     n->value_ = value_;
     n->prefix = prefix;
     if (children_)
-      n->children_ = std::make_unique<ChildVec>(*children_);
+      n->children_ = std::make_unique<ChildStore>(*children_);
     return n;
   }
 
@@ -604,10 +636,10 @@ private:
       }
       auto transition = remaining[0];
       remaining = remaining.subspan(1);
-      auto *child = cur->find_child(transition);
+      auto child = cur->find_child(transition);
       if (!child)
         return nullptr;
-      cur = child->second.get();
+      cur = child->ptr.get();
     }
     return nullptr;
   }
@@ -676,11 +708,11 @@ private:
     // Recurse into child.
     auto transition = remaining[0];
     auto child_key = remaining.subspan(1);
-    auto *existing_child = new_node->find_child_mut(transition);
+    auto existing_child = new_node->find_child_mut(transition);
     if (existing_child) {
       auto [new_child, inserted] =
-          set_impl(existing_child->second, child_key, std::move(val));
-      existing_child->second = std::move(new_child);
+          set_impl(existing_child->ptr, child_key, std::move(val));
+      existing_child->ptr = std::move(new_child);
       return {std::move(new_node), inserted};
     }
     // No child for this transition — create a leaf.
@@ -733,11 +765,11 @@ private:
     // Recurse.
     auto transition = remaining[0];
     auto child_key = remaining.subspan(1);
-    auto *existing = node->find_child(transition);
+    auto existing = node->find_child(transition);
     if (!existing)
       return {node, false};
 
-    auto [new_child, removed] = erase_impl(existing->second, child_key);
+    auto [new_child, removed] = erase_impl(existing->ptr, child_key);
     if (!removed)
       return {node, false};
 
@@ -755,8 +787,8 @@ private:
       }
       return {std::move(new_node), true};
     }
-    auto *child_slot = new_node->find_child_mut(transition);
-    child_slot->second = std::move(new_child);
+    auto child_slot = new_node->find_child_mut(transition);
+    child_slot->ptr = std::move(new_child);
     // Path compression on the child side: child might now be a routing node
     // with 1 child and no value — but that's the child's responsibility,
     // already handled in the recursive call.
@@ -768,8 +800,9 @@ private:
   static auto merge_with_child(IntrusivePtr<Node<V>> node)
       -> IntrusivePtr<Node<V>> {
     assert(!node->has_value() && node->child_count() == 1);
-    auto transition = node->child_at(0).first;
-    auto child = node->child_at(0).second->clone();
+    auto slot0 = node->child_at(0);
+    auto transition = slot0.transition;
+    auto child = slot0.ptr->clone();
 
     typename Node<V>::Prefix merged_prefix;
     for (auto b : node->prefix)
@@ -835,12 +868,12 @@ private:
         a_suffix.push_back(pa[i]);
       a_trimmed->prefix = std::move(a_suffix);
 
-      auto *existing = new_b->find_child_mut(pa[cpl]);
+      auto existing = new_b->find_child_mut(pa[cpl]);
       std::size_t overlaps = 0;
       if (existing) {
         auto [child, child_overlaps] =
-            merge_impl(a_trimmed, existing->second, resolve);
-        existing->second = std::move(child);
+            merge_impl(a_trimmed, existing->ptr, resolve);
+        existing->ptr = std::move(child);
         overlaps = child_overlaps;
       } else {
         new_b->insert_child(pa[cpl], std::move(a_trimmed));
@@ -858,12 +891,12 @@ private:
         b_suffix.push_back(pb[i]);
       b_trimmed->prefix = std::move(b_suffix);
 
-      auto *existing = new_a->find_child_mut(pb[cpl]);
+      auto existing = new_a->find_child_mut(pb[cpl]);
       std::size_t overlaps = 0;
       if (existing) {
         auto [child, child_overlaps] =
-            merge_impl(existing->second, b_trimmed, resolve);
-        existing->second = std::move(child);
+            merge_impl(existing->ptr, b_trimmed, resolve);
+        existing->ptr = std::move(child);
         overlaps = child_overlaps;
       } else {
         new_a->insert_child(pb[cpl], std::move(b_trimmed));
@@ -887,16 +920,16 @@ private:
 
     if (b->has_children()) {
       for (std::size_t i = 0; i < b->child_count(); ++i) {
-        auto [tb, child_b] = b->child_at(i);
-        auto *slot = merged->find_child_mut(tb);
+        auto b_slot = b->child_at(i);
+        auto slot = merged->find_child_mut(b_slot.transition);
         if (slot) {
           auto [child, child_overlaps] =
-              merge_impl(slot->second, child_b, resolve);
-          slot->second = std::move(child);
+              merge_impl(slot->ptr, b_slot.ptr, resolve);
+          slot->ptr = std::move(child);
           overlaps += child_overlaps;
         } else {
           // Disjoint subtree — share it in O(1), no clone needed.
-          merged->insert_child(tb, child_b);
+          merged->insert_child(b_slot.transition, b_slot.ptr);
         }
       }
     }
@@ -1078,11 +1111,11 @@ private:
 
     auto transition = remaining[0];
     auto child_key = remaining.subspan(1);
-    auto *existing_child = mutable_node->find_child_mut(transition);
+    auto existing_child = mutable_node->find_child_mut(transition);
     if (existing_child) {
       auto [new_child, inserted] =
-          set_transient(existing_child->second, child_key, std::move(val), tag);
-      existing_child->second = std::move(new_child);
+          set_transient(existing_child->ptr, child_key, std::move(val), tag);
+      existing_child->ptr = std::move(new_child);
       return {std::move(mutable_node), inserted};
     }
     auto leaf = make_intrusive<Node<V>>();
@@ -1162,12 +1195,12 @@ private:
 
     auto transition = remaining[0];
     auto child_key = remaining.subspan(1);
-    auto *existing_child = mutable_node->find_child_mut(transition);
+    auto existing_child = mutable_node->find_child_mut(transition);
     if (existing_child) {
       auto [new_child, displaced, inserted] = upsert_transient(
-          existing_child->second, child_key, std::move(val), tag,
+          existing_child->ptr, child_key, std::move(val), tag,
           std::forward<Pred>(should_replace));
-      existing_child->second = std::move(new_child);
+      existing_child->ptr = std::move(new_child);
       return {std::move(mutable_node), std::move(displaced), inserted};
     }
     auto leaf = make_intrusive<Node<V>>();
@@ -1211,12 +1244,12 @@ private:
 
     auto transition = remaining[0];
     auto child_key = remaining.subspan(1);
-    auto *existing = node->find_child(transition);
+    auto existing = node->find_child(transition);
     if (!existing)
       return {node, false};
 
     auto [new_child, removed] =
-        erase_transient(existing->second, child_key, tag);
+        erase_transient(existing->ptr, child_key, tag);
     if (!removed)
       return {node, false};
 
@@ -1231,8 +1264,8 @@ private:
       }
       return {std::move(mutable_node), true};
     }
-    auto *child_slot = mutable_node->find_child_mut(transition);
-    child_slot->second = std::move(new_child);
+    auto child_slot = mutable_node->find_child_mut(transition);
+    child_slot->ptr = std::move(new_child);
     return {std::move(mutable_node), true};
   }
 
@@ -1240,8 +1273,9 @@ private:
                                          std::uint32_t tag)
       -> IntrusivePtr<Node<V>> {
     assert(!node->has_value() && node->child_count() == 1);
-    auto transition = node->child_at(0).first;
-    auto child = ensure_mutable(node->child_at(0).second, tag);
+    auto slot = node->child_at(0);
+    auto transition = slot.transition;
+    auto child = ensure_mutable(slot.ptr, tag);
 
     typename Node<V>::Prefix merged_prefix;
     for (std::size_t i = 0; i < node->prefix.size(); ++i)
@@ -1400,11 +1434,11 @@ private:
     while (!stack_.empty()) {
       auto &frame = stack_.back();
       if (frame.child_idx < frame.node->child_count()) {
-        auto &[transition, child] = frame.node->child_at(frame.child_idx);
+        auto slot = frame.node->child_at(frame.child_idx);
         ++frame.child_idx;
         auto key_before = current_key_.size();
-        current_key_.push_back(transition);
-        push_node(child, key_before);
+        current_key_.push_back(slot.transition);
+        push_node(slot.ptr, key_before);
         if (stack_.back().node->has_value())
           return;
         // Continue DFS.
@@ -1424,10 +1458,10 @@ private:
       auto &frame = stack_.back();
       auto last = frame.node->child_count() - 1;
       frame.child_idx = frame.node->child_count();
-      auto &[transition, child] = frame.node->child_at(last);
+      auto slot = frame.node->child_at(last);
       auto key_before = current_key_.size();
-      current_key_.push_back(transition);
-      push_node(child, key_before);
+      current_key_.push_back(slot.transition);
+      push_node(slot.ptr, key_before);
     }
   }
 
@@ -1464,10 +1498,10 @@ private:
         // we popped (current_key_ already trimmed to frame's key_len + prefix).
         --frame.child_idx;
         auto prev_idx = frame.child_idx - 1;
-        auto &[transition, child] = frame.node->child_at(prev_idx);
+        auto slot = frame.node->child_at(prev_idx);
         auto key_before = current_key_.size();
-        current_key_.push_back(transition);
-        push_node(child, key_before);
+        current_key_.push_back(slot.transition);
+        push_node(slot.ptr, key_before);
         stack_.back().child_idx = stack_.back().node->child_count();
         descend_rightmost();
         return;
@@ -1539,7 +1573,7 @@ private:
 
       bool descended = false;
       for (std::size_t i = 0; i < cur->child_count(); ++i) {
-        auto cb = cur->child_at(i).first;
+        auto cb = cur->child_at(i).transition;
         if (cb < target_byte)
           continue;
 
@@ -1548,7 +1582,7 @@ private:
           stack_.push_back({cur, i + 1, klb});
           klb = current_key_.size();
           current_key_.push_back(cb);
-          cur = cur->child_at(i).second;
+          cur = cur->child_at(i).ptr;
           remaining = child_remaining;
           descended = true;
           break;

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -254,6 +254,8 @@ template <typename V> struct Node {
 
       std::unique_ptr<ChildStore> kids;
       if (has_kids) {
+        // Raw cast: internal_node() would re-check the flag we just read.
+        // Safe because has_kids is true and mut points to an InternalNode.
         auto* internal = static_cast<InternalNode<V>*>(mut);
         kids = std::move(internal->children_);
         delete internal;
@@ -409,7 +411,7 @@ template <typename V> struct Node {
       auto *self = internal_node();
       assert(self != nullptr);
       auto* n = new InternalNode<V>();
-      n->packed_tag_ = packed_tag_ & kFlagBits;
+      n->packed_tag_ |= packed_tag_ & kHasValueBit;
       n->value_ = value_;
       n->prefix = prefix;
       if (self->children_)
@@ -434,7 +436,7 @@ template <typename V> struct Node {
   // Used when the caller will insert children into the clone.
   [[nodiscard]] auto clone_as_internal() const -> IntrusivePtr<Node> {
     auto* n = new InternalNode<V>();
-    n->packed_tag_ = (packed_tag_ & kHasValueBit) | kHasChildrenBit;
+    n->packed_tag_ |= packed_tag_ & kHasValueBit;
     n->value_ = value_;
     n->prefix = prefix;
     if (has_children_flag()) {
@@ -453,6 +455,7 @@ template <typename V> struct Node {
 // sizeof(InternalNode<KeyDirEntry>) == 48, glibc usable=56.
 // ---------------------------------------------------------------------------
 template <typename V> struct InternalNode : Node<V> {
+  InternalNode() { Node<V>::packed_tag_ |= Node<V>::kHasChildrenBit; }
   std::unique_ptr<typename Node<V>::ChildStore> children_;
 };
 
@@ -472,9 +475,7 @@ auto make_leaf() -> IntrusivePtr<Node<V>> {
 
 template <typename V>
 auto make_internal() -> IntrusivePtr<Node<V>> {
-  auto* n = new InternalNode<V>();
-  n->packed_tag_ |= Node<V>::kHasChildrenBit;
-  return IntrusivePtr<Node<V>>::adopt(n);
+  return IntrusivePtr<Node<V>>::adopt(new InternalNode<V>());
 }
 
 // Promote a leaf node to internal. Returns a new InternalNode with the
@@ -485,9 +486,8 @@ auto promote_to_internal(const IntrusivePtr<Node<V>> &node)
     -> IntrusivePtr<Node<V>> {
   assert(!node->has_children_flag());
   auto* n = new InternalNode<V>();
-  n->packed_tag_ = (node->packed_tag_ & ~Node<V>::kFlagBits) |
-                   (node->packed_tag_ & Node<V>::kHasValueBit) |
-                   Node<V>::kHasChildrenBit;
+  n->packed_tag_ |= (node->packed_tag_ & Node<V>::kHasValueBit) |
+                    (node->packed_tag_ & Node<V>::kTagMask);
   n->value_ = node->value_;
   n->prefix = node->prefix;
   return IntrusivePtr<Node<V>>::adopt(n);
@@ -1385,7 +1385,8 @@ private:
         merged_prefix.push_back(child->prefix[i]);
       child->prefix = std::move(merged_prefix);
       return std::move(child);
-    }    std::vector<std::byte> merged;
+    }
+    std::vector<std::byte> merged;
     merged.reserve(total);
     for (std::size_t i = 0; i < node->prefix.size(); ++i)
       merged.push_back(node->prefix[i]);

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -26,168 +26,52 @@ namespace bytecask {
 // ---------------------------------------------------------------------------
 // CompactPrefix
 //
-// Fixed 16-byte container for node prefix bytes. Stores up to 15 bytes
-// inline (no heap allocation). Prefixes longer than 15 bytes spill to a
-// heap-allocated buffer.
+// Fixed 8-byte container for node prefix bytes. Stores up to 7 bytes inline.
+// No heap allocation — prefixes longer than 7 bytes are split across a chain
+// of routing nodes (each carrying up to 7 prefix bytes + 1 transition byte).
 //
-// Inline layout (size_ <= 15):
-//   size_ : length (0-15)
-//   data_[0..14] : prefix bytes
-//
-// Heap layout (size_ == kHeapFlag):
-//   data_[0..7]  : byte* pointer via memcpy
-//   data_[8..11] : uint32_t heap length via memcpy
-//
-// sizeof(CompactPrefix) == 16, alignof(CompactPrefix) == 1.
+// sizeof(CompactPrefix) == 8, alignof(CompactPrefix) == 1.
 // ---------------------------------------------------------------------------
 class CompactPrefix {
 public:
-  static constexpr std::size_t kInlineCap = 15;
+  static constexpr std::size_t kInlineCap = 7;
 
   CompactPrefix() noexcept = default;
 
-  ~CompactPrefix() { free_heap(); }
-
-  CompactPrefix(const CompactPrefix &other) : size_{other.size_} {
-    if (other.on_heap()) {
-      auto n = other.heap_size();
-      auto *buf = new std::byte[n];
-      std::memcpy(buf, other.heap_ptr(), n);
-      store_heap_ptr(buf);
-      store_heap_size(n);
-    } else {
-      std::memcpy(data_, other.data_, other.inline_size());
-    }
-  }
-
-  CompactPrefix(CompactPrefix &&other) noexcept : size_{other.size_} {
-    std::memcpy(data_, other.data_, sizeof(data_));
-    other.size_ = 0;
-  }
-
-  auto operator=(const CompactPrefix &other) -> CompactPrefix & {
-    if (this != &other) {
-      auto tmp{other};
-      *this = std::move(tmp);
-    }
-    return *this;
-  }
-
-  auto operator=(CompactPrefix &&other) noexcept -> CompactPrefix & {
-    if (this == &other)
-      return *this;
-    free_heap();
-    size_ = other.size_;
-    std::memcpy(data_, other.data_, sizeof(data_));
-    other.size_ = 0;
-    return *this;
-  }
-
-  [[nodiscard]] auto size() const noexcept -> std::size_t {
-    return on_heap() ? heap_size() : inline_size();
-  }
-
+  [[nodiscard]] auto size() const noexcept -> std::size_t { return size_; }
   [[nodiscard]] auto empty() const noexcept -> bool { return size_ == 0; }
-
-  [[nodiscard]] auto data() noexcept -> std::byte * {
-    return on_heap() ? heap_ptr() : data_;
-  }
-
+  [[nodiscard]] auto data() noexcept -> std::byte * { return data_; }
   [[nodiscard]] auto data() const noexcept -> const std::byte * {
-    return on_heap() ? heap_ptr() : data_;
+    return data_;
   }
-
   [[nodiscard]] auto operator[](std::size_t i) noexcept -> std::byte & {
-    return data()[i];
+    return data_[i];
   }
-
   [[nodiscard]] auto operator[](std::size_t i) const noexcept
       -> const std::byte & {
-    return data()[i];
+    return data_[i];
   }
-
-  [[nodiscard]] auto begin() noexcept -> std::byte * { return data(); }
-  [[nodiscard]] auto end() noexcept -> std::byte * { return data() + size(); }
+  [[nodiscard]] auto begin() noexcept -> std::byte * { return data_; }
+  [[nodiscard]] auto end() noexcept -> std::byte * { return data_ + size_; }
   [[nodiscard]] auto begin() const noexcept -> const std::byte * {
-    return data();
+    return data_;
   }
   [[nodiscard]] auto end() const noexcept -> const std::byte * {
-    return data() + size();
+    return data_ + size_;
   }
 
   void push_back(std::byte b) {
-    if (on_heap()) {
-      auto old_n = heap_size();
-      auto *old_buf = heap_ptr();
-      auto *new_buf = new std::byte[old_n + 1];
-      std::memcpy(new_buf, old_buf, old_n);
-      new_buf[old_n] = b;
-      delete[] old_buf;
-      store_heap_ptr(new_buf);
-      store_heap_size(old_n + 1);
-      return;
-    }
-    auto n = inline_size();
-    if (n < kInlineCap) {
-      data_[n] = b;
-      ++size_;
-      return;
-    }
-    // Spill: copy inline bytes + new byte to heap.
-    auto *buf = new std::byte[kInlineCap + 1];
-    std::memcpy(buf, data_, kInlineCap);
-    buf[kInlineCap] = b;
-    store_heap_ptr(buf);
-    store_heap_size(kInlineCap + 1);
-    size_ = kHeapFlag;
+    assert(size_ < kInlineCap);
+    data_[size_++] = b;
   }
 
-  void clear() {
-    free_heap();
-    size_ = 0;
-  }
+  void clear() { size_ = 0; }
 
 private:
-  static constexpr std::uint8_t kHeapFlag = 0xFF;
-
-  [[nodiscard]] auto on_heap() const noexcept -> bool {
-    return size_ == kHeapFlag;
-  }
-
-  [[nodiscard]] auto inline_size() const noexcept -> std::size_t {
-    return size_;
-  }
-
-  [[nodiscard]] auto heap_size() const noexcept -> std::size_t {
-    std::uint32_t n;
-    std::memcpy(&n, data_ + 8, sizeof(n));
-    return n;
-  }
-
-  void store_heap_size(std::size_t n) noexcept {
-    auto n32 = static_cast<std::uint32_t>(n);
-    std::memcpy(data_ + 8, &n32, sizeof(n32));
-  }
-
-  [[nodiscard]] auto heap_ptr() const noexcept -> std::byte * {
-    std::byte *p;
-    std::memcpy(&p, data_, sizeof(p));
-    return p;
-  }
-
-  void store_heap_ptr(std::byte *p) noexcept {
-    std::memcpy(data_, &p, sizeof(p));
-  }
-
-  void free_heap() noexcept {
-    if (on_heap())
-      delete[] heap_ptr();
-  }
-
   std::uint8_t size_{0};
   std::byte data_[kInlineCap]{};
 };
-static_assert(sizeof(CompactPrefix) == 16);
+static_assert(sizeof(CompactPrefix) == 8);
 static_assert(alignof(CompactPrefix) == 1);
 
 // ---------------------------------------------------------------------------
@@ -495,6 +379,10 @@ template <typename V> struct Node {
   }
 };
 
+// Check Node size after CompactPrefix shrink (16B → 8B).
+// Node<uint64_t>: 4+4+8+8+8 = 32.
+static_assert(sizeof(Node<std::uint64_t>) == 32);
+
 // ---------------------------------------------------------------------------
 // Helper: compute the common prefix length between a node's prefix and a key
 // slice.
@@ -644,18 +532,115 @@ private:
     return nullptr;
   }
 
+  // -- chain builders --
+  // Build a chain of routing nodes ending in a value-bearing leaf.
+  // Chunks key left-to-right: each intermediate node gets 7 prefix bytes +
+  // 1 transition byte (8 bytes of key material per hop). The final leaf
+  // gets the remaining 0–7 bytes as prefix.
+  static auto build_leaf_chain(std::span<const std::byte> key, V val,
+                               std::uint32_t tag = 0)
+      -> IntrusivePtr<Node<V>> {
+    // Fast path: key fits in a single node's prefix.
+    if (key.size() <= CompactPrefix::kInlineCap) {
+      auto leaf = make_intrusive<Node<V>>();
+      if (tag)
+        leaf->set_edit_tag(tag);
+      for (auto b : key)
+        leaf->prefix.push_back(b);
+      leaf->set_value(std::move(val));
+      return leaf;
+    }
+
+    // Partition key into chunks of 7 prefix + 1 transition byte.
+    // Collect chunk boundaries first, then build bottom-up.
+    struct Chunk {
+      std::size_t prefix_start;
+      std::size_t prefix_len;
+      std::size_t transition_idx; // index of transition byte (unused for last)
+    };
+    std::vector<Chunk> chunks;
+    std::size_t pos = 0;
+    while (key.size() - pos > CompactPrefix::kInlineCap) {
+      chunks.push_back({pos, CompactPrefix::kInlineCap, pos + CompactPrefix::kInlineCap});
+      pos += CompactPrefix::kInlineCap + 1; // 7 prefix + 1 transition
+    }
+    // Last chunk: remaining 0–7 bytes become the leaf's prefix.
+    auto leaf_prefix = key.subspan(pos);
+
+    // Build bottom-up: leaf first, then wrap in routing nodes.
+    auto cur = make_intrusive<Node<V>>();
+    if (tag)
+      cur->set_edit_tag(tag);
+    for (auto b : leaf_prefix)
+      cur->prefix.push_back(b);
+    cur->set_value(std::move(val));
+
+    for (auto it = chunks.rbegin(); it != chunks.rend(); ++it) {
+      auto routing = make_intrusive<Node<V>>();
+      if (tag)
+        routing->set_edit_tag(tag);
+      for (std::size_t i = 0; i < it->prefix_len; ++i)
+        routing->prefix.push_back(key[it->prefix_start + i]);
+      routing->insert_child(key[it->transition_idx], std::move(cur));
+      cur = std::move(routing);
+    }
+    return cur;
+  }
+
+  // Build a chain of routing nodes with an existing terminal node at the end.
+  // Overwrites terminal->prefix with the last chunk. Leaves terminal's
+  // children and value intact.
+  static auto build_routing_chain(std::span<const std::byte> merged,
+                                  IntrusivePtr<Node<V>> terminal,
+                                  std::uint32_t tag = 0)
+      -> IntrusivePtr<Node<V>> {
+    // Fast path: fits in a single prefix.
+    if (merged.size() <= CompactPrefix::kInlineCap) {
+      terminal->prefix.clear();
+      for (auto b : merged)
+        terminal->prefix.push_back(b);
+      return terminal;
+    }
+
+    // Partition into chunks.
+    struct Chunk {
+      std::size_t prefix_start;
+      std::size_t prefix_len;
+      std::size_t transition_idx;
+    };
+    std::vector<Chunk> chunks;
+    std::size_t pos = 0;
+    while (merged.size() - pos > CompactPrefix::kInlineCap) {
+      chunks.push_back({pos, CompactPrefix::kInlineCap, pos + CompactPrefix::kInlineCap});
+      pos += CompactPrefix::kInlineCap + 1;
+    }
+
+    // Set terminal's prefix to the last chunk.
+    terminal->prefix.clear();
+    for (auto b : merged.subspan(pos))
+      terminal->prefix.push_back(b);
+
+    // Build bottom-up: terminal is the innermost node.
+    auto cur = std::move(terminal);
+    for (auto it = chunks.rbegin(); it != chunks.rend(); ++it) {
+      auto routing = make_intrusive<Node<V>>();
+      if (tag)
+        routing->set_edit_tag(tag);
+      for (std::size_t i = 0; i < it->prefix_len; ++i)
+        routing->prefix.push_back(merged[it->prefix_start + i]);
+      routing->insert_child(merged[it->transition_idx], std::move(cur));
+      cur = std::move(routing);
+    }
+    return cur;
+  }
+
   // -- set (returns new root + whether a new key was inserted) --
   static auto set_impl(const IntrusivePtr<Node<V>> &node,
                        std::span<const std::byte> key, V val)
       -> std::pair<IntrusivePtr<Node<V>>, bool> {
     if (!node) {
-      // Create a leaf.
-      auto leaf = make_intrusive<Node<V>>();
-      leaf->prefix = typename Node<V>::Prefix{};
-      for (auto b : key)
-        leaf->prefix.push_back(b);
-      leaf->set_value(std::move(val));
-      return {std::move(leaf), true};
+      // Create a leaf (chain-split if key > 7 bytes).
+      return {build_leaf_chain(key, std::move(val)), true};
     }
 
     auto new_node = node->clone();
@@ -687,11 +672,8 @@ private:
         split->set_value(std::move(val));
       } else {
         auto new_transition = remaining[0];
-        auto new_leaf = make_intrusive<Node<V>>();
-        for (auto b : remaining.subspan(1))
-          new_leaf->prefix.push_back(b);
-        new_leaf->set_value(std::move(val));
-        split->insert_child(new_transition, std::move(new_leaf));
+        auto chain = build_leaf_chain(remaining.subspan(1), std::move(val));
+        split->insert_child(new_transition, std::move(chain));
       }
       return {std::move(split), true};
     }
@@ -716,11 +698,8 @@ private:
       return {std::move(new_node), inserted};
     }
     // No child for this transition — create a leaf.
-    auto leaf = make_intrusive<Node<V>>();
-    for (auto b : child_key)
-      leaf->prefix.push_back(b);
-    leaf->set_value(std::move(val));
-    new_node->insert_child(transition, std::move(leaf));
+    auto chain = build_leaf_chain(child_key, std::move(val));
+    new_node->insert_child(transition, std::move(chain));
     return {std::move(new_node), true};
   }
 
@@ -797,6 +776,7 @@ private:
 
   // Merge a routing node (no value) with its single child.
   // New prefix = node.prefix + transition_byte + child.prefix
+  // If combined prefix > 7 bytes, builds a chain of routing nodes.
   static auto merge_with_child(IntrusivePtr<Node<V>> node)
       -> IntrusivePtr<Node<V>> {
     assert(!node->has_value() && node->child_count() == 1);
@@ -804,14 +784,28 @@ private:
     auto transition = slot0.transition;
     auto child = slot0.ptr->clone();
 
-    typename Node<V>::Prefix merged_prefix;
+    auto total = node->prefix.size() + 1 + child->prefix.size();
+    if (total <= CompactPrefix::kInlineCap) {
+      // Fast path: fits in a single prefix.
+      typename Node<V>::Prefix merged_prefix;
+      for (auto b : node->prefix)
+        merged_prefix.push_back(b);
+      merged_prefix.push_back(transition);
+      for (std::size_t i = 0; i < child->prefix.size(); ++i)
+        merged_prefix.push_back(child->prefix[i]);
+      child->prefix = std::move(merged_prefix);
+      return std::move(child);
+    }
+    // Overflow: collect merged bytes, build a routing chain.
+    std::vector<std::byte> merged;
+    merged.reserve(total);
     for (auto b : node->prefix)
-      merged_prefix.push_back(b);
-    merged_prefix.push_back(transition);
+      merged.push_back(b);
+    merged.push_back(transition);
     for (std::size_t i = 0; i < child->prefix.size(); ++i)
-      merged_prefix.push_back(child->prefix[i]);
-    child->prefix = std::move(merged_prefix);
-    return child;
+      merged.push_back(child->prefix[i]);
+    return build_routing_chain(std::span<const std::byte>{merged},
+                               std::move(child));
   }
 
   // -- merge_impl --
@@ -1041,6 +1035,8 @@ private:
   // to allow in-place mutation. The refcount check defends against tag
   // wraparound after 2^31 transient sessions: even if an old node
   // happens to carry the same 31-bit tag, it will be cloned if shared.
+  using Ops = PersistentRadixTree<V>;
+
   static auto ensure_mutable(const IntrusivePtr<Node<V>> &node,
                              std::uint32_t tag) -> IntrusivePtr<Node<V>> {
     if (node && node->edit_tag() == tag &&
@@ -1060,12 +1056,7 @@ private:
                             std::uint32_t tag)
       -> std::pair<IntrusivePtr<Node<V>>, bool> {
     if (!node) {
-      auto leaf = make_intrusive<Node<V>>();
-      leaf->set_edit_tag(tag);
-      for (auto b : key)
-        leaf->prefix.push_back(b);
-      leaf->set_value(std::move(val));
-      return {std::move(leaf), true};
+      return {Ops::build_leaf_chain(key, std::move(val), tag), true};
     }
 
     auto mutable_node = ensure_mutable(node, tag);
@@ -1092,12 +1083,8 @@ private:
         split->set_value(std::move(val));
       } else {
         auto new_transition = remaining[0];
-        auto new_leaf = make_intrusive<Node<V>>();
-        new_leaf->set_edit_tag(tag);
-        for (auto b : remaining.subspan(1))
-          new_leaf->prefix.push_back(b);
-        new_leaf->set_value(std::move(val));
-        split->insert_child(new_transition, std::move(new_leaf));
+        auto chain = Ops::build_leaf_chain(remaining.subspan(1), std::move(val), tag);
+        split->insert_child(new_transition, std::move(chain));
       }
       return {std::move(split), true};
     }
@@ -1118,12 +1105,8 @@ private:
       existing_child->ptr = std::move(new_child);
       return {std::move(mutable_node), inserted};
     }
-    auto leaf = make_intrusive<Node<V>>();
-    leaf->set_edit_tag(tag);
-    for (auto b : child_key)
-      leaf->prefix.push_back(b);
-    leaf->set_value(std::move(val));
-    mutable_node->insert_child(transition, std::move(leaf));
+    auto chain = Ops::build_leaf_chain(child_key, std::move(val), tag);
+    mutable_node->insert_child(transition, std::move(chain));
     return {std::move(mutable_node), true};
   }
 
@@ -1137,12 +1120,7 @@ private:
                                std::uint32_t tag, Pred &&should_replace)
       -> std::tuple<IntrusivePtr<Node<V>>, std::optional<V>, bool> {
     if (!node) {
-      auto leaf = make_intrusive<Node<V>>();
-      leaf->set_edit_tag(tag);
-      for (auto b : key)
-        leaf->prefix.push_back(b);
-      leaf->set_value(std::move(val));
-      return {std::move(leaf), std::nullopt, true};
+      return {Ops::build_leaf_chain(key, std::move(val), tag), std::nullopt, true};
     }
 
     auto mutable_node = ensure_mutable(node, tag);
@@ -1169,12 +1147,8 @@ private:
         split->set_value(std::move(val));
       } else {
         auto new_transition = remaining[0];
-        auto new_leaf = make_intrusive<Node<V>>();
-        new_leaf->set_edit_tag(tag);
-        for (auto b : remaining.subspan(1))
-          new_leaf->prefix.push_back(b);
-        new_leaf->set_value(std::move(val));
-        split->insert_child(new_transition, std::move(new_leaf));
+        auto chain = Ops::build_leaf_chain(remaining.subspan(1), std::move(val), tag);
+        split->insert_child(new_transition, std::move(chain));
       }
       return {std::move(split), std::nullopt, true};
     }
@@ -1203,12 +1177,8 @@ private:
       existing_child->ptr = std::move(new_child);
       return {std::move(mutable_node), std::move(displaced), inserted};
     }
-    auto leaf = make_intrusive<Node<V>>();
-    leaf->set_edit_tag(tag);
-    for (auto b : child_key)
-      leaf->prefix.push_back(b);
-    leaf->set_value(std::move(val));
-    mutable_node->insert_child(transition, std::move(leaf));
+    auto chain = Ops::build_leaf_chain(child_key, std::move(val), tag);
+    mutable_node->insert_child(transition, std::move(chain));
     return {std::move(mutable_node), std::nullopt, true};
   }
 
@@ -1277,14 +1247,25 @@ private:
     auto transition = slot.transition;
     auto child = ensure_mutable(slot.ptr, tag);
 
-    typename Node<V>::Prefix merged_prefix;
+    auto total = node->prefix.size() + 1 + child->prefix.size();
+    if (total <= CompactPrefix::kInlineCap) {
+      typename Node<V>::Prefix merged_prefix;
+      for (std::size_t i = 0; i < node->prefix.size(); ++i)
+        merged_prefix.push_back(node->prefix[i]);
+      merged_prefix.push_back(transition);
+      for (std::size_t i = 0; i < child->prefix.size(); ++i)
+        merged_prefix.push_back(child->prefix[i]);
+      child->prefix = std::move(merged_prefix);
+      return std::move(child);
+    }    std::vector<std::byte> merged;
+    merged.reserve(total);
     for (std::size_t i = 0; i < node->prefix.size(); ++i)
-      merged_prefix.push_back(node->prefix[i]);
-    merged_prefix.push_back(transition);
+      merged.push_back(node->prefix[i]);
+    merged.push_back(transition);
     for (std::size_t i = 0; i < child->prefix.size(); ++i)
-      merged_prefix.push_back(child->prefix[i]);
-    child->prefix = std::move(merged_prefix);
-    return child;
+      merged.push_back(child->prefix[i]);
+    return Ops::build_routing_chain(std::span<const std::byte>{merged},
+                               std::move(child), tag);
   }
 
   friend class PersistentRadixTree<V>;

--- a/docs/bytecask_design.md
+++ b/docs/bytecask_design.md
@@ -18,7 +18,7 @@ Canonical location: `docs/bytecask_design.md`.
 
 - Provide a clean, minimal API surface for key-value operations.
 - Support atomic multi-operation batches.
-- Support ordered range iteration (enabled by the B-Tree key directory).
+- Support ordered range iteration (enabled by the radix-tree key directory).
 - Be idiomatic C++23: no raw pointers, no stringly-typed errors, move-only ownership.
 
 ## Non-Goals (for now)
@@ -72,11 +72,15 @@ The design follows these core tenets in order of priority:
 
 ByteCaskDB uses `PersistentRadixTree<KeyDirEntry>` as the in-memory key directory. All keys reside in memory at all times.
 
-The key directory is a persistent (immutable) radix tree with path-compressed nodes, intrusive reference counting, and structural sharing across versions. It provides O(k) get/set/erase (where k = key length), bidirectional ordered iteration via DFS, `lower_bound()` / `upper_bound()` for range queries, `rbegin()` / `rend()` for safe reverse iteration via `ReverseRadixTreeIterator`, and a `transient()` / `persistent()` API for batch mutations. `RadixTreeIterator` satisfies `std::bidirectional_iterator` — `operator--` walks the tree in reverse with O(1) amortized cost per step. `ReverseRadixTreeIterator` wraps `RadixTreeIterator` with pre-decrement at construction so `operator*` always returns a span into a live iterator buffer — no dangling references. It also tracks a `past_rend_` flag so `++rend()` is a no-op (never wraps back to the last element) and `rend().base() == begin()` holds (standard reverse_iterator semantics). Implemented in `bytecask.radix_tree` (`src/engine/radix_tree.cppm`).
+The key directory is a persistent (immutable) radix tree with path-compressed nodes, intrusive reference counting, and structural sharing across versions. It provides O(k) get/set/erase (where k = key length), bidirectional ordered iteration via DFS, `lower_bound()` / `upper_bound()` for range queries, `rbegin()` / `rend()` for safe reverse iteration via `ReverseRadixTreeIterator`, and a `transient()` / `persistent()` API for batch mutations. `RadixTreeIterator` satisfies `std::bidirectional_iterator` — `operator--` walks the tree in reverse with O(1) amortized cost per step. `ReverseRadixTreeIterator` wraps `RadixTreeIterator` with pre-decrement at construction so `operator*` always returns a span into a live iterator buffer — no dangling references. It also tracks a `past_rend_` flag so `++rend()` is a no-op (never wraps back to the last element) and `rend().base() == begin()` holds (standard reverse_iterator semantics). Implemented in `bytecask.radix_tree` (`bytecaskdb/radix_tree.cppm`).
+
+`TransientRadixTree` is intentionally single-use. `persistent() &&` retires the builder, and any later read or write on a consumed or moved-from transient throws `std::logic_error` in release builds instead of relying on debug-only assertions.
 
 `Node::release()` uses iterative tail-release: when the last child's refcount drops to zero, the loop continues with that child instead of recursing through `~IntrusivePtr`. This avoids O(depth) recursive destructor frames for chains of single-child nodes — the dominant pattern in compressed radix trees. Profiling (perf, MergeOverlapping/100K) measured the recursive `~IntrusivePtr` cascade at 29% of total merge time; the iterative version reduces MergeOverlapping by ~6% and parallel recovery at 16T by ~13%.
 
 `TransientRadixTree::upsert(key, val, should_replace)` performs a single-traversal conditional insert-or-replace: it walks from root to leaf once, inserting if the key is absent, or replacing if `should_replace(existing, incoming)` returns true. Returns the displaced old value when a replacement occurs, enabling callers to track side-effects (e.g. file_stats adjustment). Used by parallel recovery's `recovery_build_from_hints` to eliminate the separate `get()` + `set()` dual traversal that profiling (perf, Recovery/Parallel/16) showed consuming ~49% of recovery time.
+
+Child storage remains behind the `Node` / `InternalNode` split. `child_count`, `child_at`, `find_child`, and the mutation helpers now funnel through checked accessors that return safe defaults for leaf nodes instead of repeating flag checks plus open-coded downcasts at each call site.
 
 Keys are stored as byte sequences within the radix tree's prefix-compressed nodes. The radix tree API accepts `std::span<const std::byte>` for all key parameters — no intermediate `Key` wrapper is needed for internal operations. The public `Key` class (backed by `std::vector<std::byte>`) is retained for the external iterator API (`KeyIterator`, `EntryIterator`) and for the recovery tombstone tracking map. `Key` provides `operator<=>` (lexicographic over raw byte values) and `begin()`/`end()`/`size()` accessors. Keys have a hard upper bound of 65 535 bytes (the `u16 key_size` field in the data file header).
 

--- a/docs/bytecask_project_plan.md
+++ b/docs/bytecask_project_plan.md
@@ -52,6 +52,7 @@ Canonical location: `docs/bytecask_project_plan.md`.
 | BC-092 | UUIDv4 test | Test and protections if customers use UUIDv4 as key (Maybe we will need a Adaptive Radix Tree extension) |
 | BC-188 | Tombstone GC during vacuum | Point and range tombstones are currently preserved forever. Vacuum should elide tombstones that are older than all live data files, since no recovery can need them. |
 | BC-189 | Radix tree `erase_range(from, to)` | Current `del_range` erases keys one-by-one after collecting them. A native `erase_range` on PersistentRadixTree could delete entire subtrees in O(subtree) instead of O(N) individual erases. |
+| BC-215 | Refresh stale coverage artifact | The checked-in `lcov.info` no longer matches the current radix-tree symbols/tests and should not be treated as current coverage evidence. Either regenerate it from the current coverage workflow or remove it from review flows. |
 | BC-093 | Vacuum benchmarks | Add benchmark tests for the vacuum (with performance and data file reclaim tests) |
 | BC-094 | Profile memory | Profile memory usage (maybe benchmark tests that capture that) |
 | BC-125 | ~~`WriteOptions::sync_before_visible`~~ | Obsolete. Durability-before-visibility is now the default. `state_.store()` happens after `fdatasync`. |
@@ -65,6 +66,7 @@ Canonical location: `docs/bytecask_project_plan.md`.
 
 | ID | Title | Note |
 | --- | --- | --- |
+| BC-214 | Radix tree safety hardening | `TransientRadixTree` now throws `std::logic_error` on consumed or moved-from reuse in release builds. Child access is centralized through checked `Node`/`InternalNode` helpers instead of repeated flag-plus-cast patterns. Added 2 regression tests; `[radix_tree]` passes with 57 cases and 1,059,164 assertions. |
 | BC-206 | Radix tree node memory optimization (80B→56B) | Two changes: (1) reorder `KeyDirEntry` fields to eliminate 8B alignment padding (sequence, file_offset, file_id, value_size — both uint64_t fields adjacent). (2) Replace `SmallVector<byte,24>` (32B) with `CompactPrefix` (16B): 1-byte size + 15 inline bytes, heap spill via memcpy pointer storage for prefixes >15 bytes. Node struct stays 56B but with `KeyDirEntry` (24B) as value type instead of `int` (4B+padding). Measured: 70 B/key generic (−19% from 86), 74 B/key prefixed (−19% from 92). 1045 tests pass (1.28M assertions). |
 | BC-207 | File naming format change | New format: `data_{YYYYMMDDHHmmss}_{RRRRRRRR}_V{XX}`. Dropped false microsecond precision and monotonic counter. Timestamp is now second-precision UTC creation-time hint (not content age). Random 4-byte hex salt replaces counter for collision avoidance. Added file format version tag (`V01`). Updated D11 in design docs, file_format.md naming section. |
 | BC-208 | Add ReadOptions to Snapshot methods and DB::contains_key | All read methods on Snapshot and DB now take `const ReadOptions&` for symmetry. Snapshot `get`/`iter_from`/`riter_from` no longer hardcode `verify_checksums=true` — caller controls CRC verification. Updated C API, Python bindings, Node/WASM bindings, type stubs. Fixed WASM bug where snapshot methods accepted but ignored ReadOptions. |

--- a/docs/persistent_radix_tree_design.md
+++ b/docs/persistent_radix_tree_design.md
@@ -211,7 +211,7 @@ struct Node {
 
 `PersistentRadixTree` and `TransientRadixTree` use explicit move constructors/assignments that reset the source's `size_` (and `tag_` for transient) to zero via `std::exchange`. This ensures a moved-from tree is in a valid empty state (`size() == 0`, `empty() == true`) rather than carrying stale metadata while the root pointer has been transferred.
 
-Children are stored behind a `unique_ptr` so leaf nodes (94% of all nodes) carry only the 8-byte null pointer instead of embedding an empty vector. Internal nodes allocate the vector on first `insert_child()` call. Access is via `child_count()`, `child_at()`, and `has_children()` helpers.
+Children are stored behind a `unique_ptr` so leaf nodes (94% of all nodes) carry only the 8-byte null pointer instead of embedding an empty vector. Internal nodes allocate the vector on first `insert_child()` call. Access is via `child_count()`, `child_at()`, `find_child()`, and the related mutation helpers, which centralize the `Node` / `InternalNode` split and return safe defaults for leaves.
 
 `CompactPrefix` is a fixed 16-byte container (1-byte size + 15 inline bytes, `alignof == 1`). Prefixes up to 15 bytes are stored inline with no heap allocation. Prefixes longer than 15 bytes spill to a heap buffer: the pointer is stored in the first 8 bytes of the inline array via `memcpy` and the heap size in bytes 8–11 — well-defined C++ with no strict aliasing violation. In practice, radix tree splits produce prefixes that are overwhelmingly shorter than 15 bytes (the 16-byte UUIDv7 binary segments are the longest common case), so the heap path is rarely taken.
 
@@ -221,6 +221,7 @@ The `transient()` / `persistent()` API pattern — a mutable builder that freeze
 *   During a transient mutation, if the traversed node's `edit_tag` matches the session's tag **and** the node's reference count is 1 (uniquely owned), the node is mutated **in-place**.
 *   If the tag differs (e.g., `0` or an older session) or the node is shared (refcount > 1), the node is **copied**, the copy is tagged with the current session ID, and the mutation applies to the copy.
 *   The refcount guard defends against edit-tag wraparound: after 2^31 `transient()` calls the 31-bit tag space can repeat, but a shared node will never be mutated in place regardless of its tag.
+*   A transient is single-use. `persistent() &&` retires the session tag, and any later operation on a consumed or moved-from builder throws `std::logic_error` in release builds instead of depending on debug-only assertions.
 
 ---
 
@@ -241,14 +242,14 @@ All operations leave the original tree unchanged and return a new instance.
 
 
 ### 4.2. Transient API (`TransientRadixTree<V>`)
-Operations mutate the tree in-place utilizing the COW epoch logic.
+Operations mutate the tree in-place utilizing the COW epoch logic. A consumed or moved-from transient is invalid for further use; every public entrypoint fails fast with `std::logic_error`.
 
 *   `std::optional<V> get(std::span<const std::byte> key) const` *(Reads the current state of the transient tree)*
 *   `bool contains(std::span<const std::byte> key) const`
 *   `void set(std::span<const std::byte> key, V val)`
 *   `template <typename Pred> std::optional<V> upsert(std::span<const std::byte> key, V val, Pred&& should_replace)` — Single-traversal insert-or-conditional-replace. If the key is absent, inserts `val` and returns `nullopt`. If the key is present, calls `should_replace(existing, val)`; if true, replaces the value and returns the displaced old value; if false, leaves the value unchanged and returns `nullopt`.
 *   `bool erase(std::span<const std::byte> key)`
-*   `PersistentRadixTree<V> persistent() &&` *(Consumes the builder; the transient must not be used after this call)*
+*   `PersistentRadixTree<V> persistent() &&` *(Consumes the builder; subsequent use throws `std::logic_error`)*
 
 
 ### 4.3. Iterator API (`Iterator`)

--- a/tests/radix_tree_test.cpp
+++ b/tests/radix_tree_test.cpp
@@ -785,11 +785,11 @@ TEST_CASE("RadixTree erase empty key", "[radix_tree]") {
 }
 
 // ---------------------------------------------------------------------------
-// Long keys: prefix > 15 bytes triggers CompactPrefix heap spill
+// Long keys: prefix > 7 bytes triggers chain-split routing nodes
 // ---------------------------------------------------------------------------
-TEST_CASE("RadixTree long keys spill CompactPrefix", "[radix_tree]") {
-  // Key at the inline boundary (15 bytes as prefix after split).
-  std::string boundary(16, 'b');
+TEST_CASE("RadixTree long keys chain-split", "[radix_tree]") {
+  // Key at the inline boundary (7 bytes as prefix after split).
+  std::string boundary(8, 'b');
   auto t0 = Tree{}.set(to_bytes(boundary), 42);
   CHECK(*t0.get(to_bytes(boundary)) == 42);
 

--- a/tests/radix_tree_test.cpp
+++ b/tests/radix_tree_test.cpp
@@ -930,6 +930,47 @@ TEST_CASE("RadixTree transient overwrite", "[radix_tree]") {
 }
 
 // ---------------------------------------------------------------------------
+// Transient: consumed builders fail fast in release builds
+// ---------------------------------------------------------------------------
+TEST_CASE("RadixTree consumed transient rejects reuse", "[radix_tree]") {
+  auto tr = Tree{}.transient();
+  tr.set(to_bytes("key"), 1);
+
+  auto t = std::move(tr).persistent();
+  REQUIRE(t.size() == 1U);
+  REQUIRE(*t.get(to_bytes("key")) == 1);
+
+  auto greater = [](int existing, int incoming) {
+    return incoming > existing;
+  };
+
+  CHECK_THROWS_AS(tr.get(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(tr.get_ptr(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(tr.contains(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(tr.lower_bound(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(tr.set(to_bytes("other"), 2), std::logic_error);
+  CHECK_THROWS_AS(tr.upsert(to_bytes("key"), 2, greater), std::logic_error);
+  CHECK_THROWS_AS(tr.erase(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(std::move(tr).persistent(), std::logic_error);
+}
+
+TEST_CASE("RadixTree moved-from transient rejects reuse", "[radix_tree]") {
+  auto original = Tree{}.transient();
+  original.set(to_bytes("key"), 1);
+
+  auto moved = std::move(original);
+  moved.set(to_bytes("other"), 2);
+
+  CHECK_THROWS_AS(original.get(to_bytes("key")), std::logic_error);
+  CHECK_THROWS_AS(original.set(to_bytes("x"), 3), std::logic_error);
+
+  auto t = std::move(moved).persistent();
+  CHECK(t.size() == 2U);
+  CHECK(*t.get(to_bytes("key")) == 1);
+  CHECK(*t.get(to_bytes("other")) == 2);
+}
+
+// ---------------------------------------------------------------------------
 // Transient: erase triggers path compression
 // ---------------------------------------------------------------------------
 TEST_CASE("RadixTree transient erase path compression", "[radix_tree]") {


### PR DESCRIPTION
## Summary

Three structural optimizations to the persistent radix tree's Node layout, reducing per-key memory overhead from ~90 B/key to ~69 B/key (text keys at 1M keys). Together they save ~21 B/key — a 23% reduction.

- **SoA child slot layout** — Replace `vector<pair<byte, IntrusivePtr>>` with parallel vectors of transition bytes and child pointers, eliminating 7 bytes of alignment padding per child slot
- **CompactPrefix 16B→8B** — Shrink inline prefix from 15 bytes to 7 bytes with chain-split routing nodes for longer prefixes. Crosses glibc malloc size class boundary when combined with the Node/InternalNode split
- **Node/InternalNode split** — Move `children_` into a derived `InternalNode` type. 94% of nodes are leaves allocated at 40 bytes (glibc usable=40) instead of 48 bytes (usable=56), saving 16 bytes per leaf. Safe by construction: accessing `children_` through a `Node*` is a compile error
- **Hardened child access safety** — Centralized all InternalNode downcasts through `internal_node()` / `child_store_or_null()` checked accessors. TransientRadixTree throws `std::logic_error` on use-after-consume (was assert-only)
- **InternalNode constructor guarantee** — `kHasChildrenBit` is now set by InternalNode's constructor, making it impossible to forget at construction sites

### Measured results at 1M keys

| Key format | Before | After | Saved |
|---|---|---|---|
| Text (42B UUIDv7) | ~90 B/key | 69.3 B/key | ~21 B/key |
| Binary (17B UUIDv7) | ~75 B/key | 63.8 B/key | ~11 B/key |

### At 100M keys

| Key format | RSS | B/key overhead |
|---|---|---|
| Text (42B) | 6,756 MiB | ~68 B/key |
| Binary (17B) | 6,196 MiB | ~63 B/key |

Also fixes WASM build (missing `bytecask.counters` module, embind lambda compatibility).

## Test plan

- [x] All 1,328,790 assertions pass across 1,062 test cases (`xmake run bytecask_tests`)
- [x] Memory profile confirms savings at 50K, 1M, and 100M keys
- [x] WASM build completes successfully (`bash build.sh`)