### PR TITLE
Add ARM64 build path support

### DIFF
--- a/bytecaskdb-mariadb-plugin/CMakeLists.txt
+++ b/bytecaskdb-mariadb-plugin/CMakeLists.txt
@@ -45,10 +45,20 @@ if(NOT DEFINED BYTECASK_ROOT)
   set(BYTECASK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
 endif()
 
+# xmake names its output arch dir "x86_64" or "arm64", matching uname -m
+# except aarch64 -> arm64.
+if(NOT DEFINED BYTECASK_ARCH)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    set(BYTECASK_ARCH "arm64")
+  else()
+    set(BYTECASK_ARCH "x86_64")
+  endif()
+endif()
+
 # Location of the prebuilt static archive.
 if(NOT DEFINED BYTECASK_LIB)
   set(BYTECASK_LIB
-      "${BYTECASK_ROOT}/build/linux/x86_64/release/libbytecask.a")
+      "${BYTECASK_ROOT}/build/linux/${BYTECASK_ARCH}/release/libbytecask.a")
 endif()
 
 if(NOT EXISTS "${BYTECASK_LIB}")
@@ -62,7 +72,7 @@ set(BYTECASK_INCLUDE_DIR "${BYTECASK_ROOT}/include")
 
 # Location of the testing archive (with BYTECASK_TESTING defined).
 set(BYTECASK_TESTING_LIB
-    "${BYTECASK_ROOT}/build/linux/x86_64/release/libbytecask_testing.a")
+    "${BYTECASK_ROOT}/build/linux/${BYTECASK_ARCH}/release/libbytecask_testing.a")
 
 # MariaDB include directory.  Try to find it automatically or accept override.
 if(NOT DEFINED MARIADB_INCLUDE_DIR)

--- a/scripts/benchmark_showcase.py
+++ b/scripts/benchmark_showcase.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -41,7 +42,19 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 REPO_ROOT    = Path(__file__).resolve().parent.parent
-BENCH_BINARY = REPO_ROOT / "build/linux/x86_64/release/engine_bench"
+
+
+def _xmake_arch() -> str:
+    """Return the xmake architecture directory for the current host."""
+    arch = platform.machine().lower()
+    if arch in {"aarch64", "arm64"}:
+        return "arm64"
+    if arch in {"x86_64", "amd64"}:
+        return "x86_64"
+    raise RuntimeError(f"Unsupported host architecture for xmake output: {arch}")
+
+
+BENCH_BINARY = REPO_ROOT / f"build/linux/{_xmake_arch()}/release/engine_bench"
 TMPDIR       = REPO_ROOT / ".tmp"
 
 FULL_REGULAR_SIZES   = [50_000, 500_000, 1_000_000]


### PR DESCRIPTION
Add architecture-aware build paths for ARM64 hosts.

- Select `arm64` or `x86_64` for the prebuilt ByteCask static libraries in the MariaDB plugin CMake configuration.
- Resolve the benchmark binary path from the host architecture, including `aarch64` and `arm64` aliases.

The branch was pushed as `arm64-support`.