### PR TITLE
Defer PK dup-check to commit for plain autocommit INSERT (P3)

### DIFF
--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -288,8 +288,12 @@ int MariaDBTxn::commit(THD * /*thd*/, bool all) {
       reset();
       if (deferred) {
         // Snapshot-less plan: the only precondition is ensure_absent, so a
-        // conflict is a duplicate primary key.
-        my_error(ER_DUP_ENTRY, MYF(0), "", "PRIMARY");
+        // conflict is a duplicate primary key. ER_DUP_ENTRY_WITH_KEY_NAME
+        // (not ER_DUP_ENTRY) takes two strings — "Duplicate entry '%s' for
+        // key '%s'" — matching the (value, key-name) args passed here.
+        // ER_DUP_ENTRY's second placeholder is an integer key index, so
+        // passing "PRIMARY" there is undefined behavior on the varargs call.
+        my_error(ER_DUP_ENTRY_WITH_KEY_NAME, MYF(0), "", "PRIMARY");
         return HA_ERR_FOUND_DUPP_KEY;
       }
       my_error(ER_LOCK_DEADLOCK, MYF(0));

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -43,8 +43,9 @@ void MariaDBTxn::begin_if_needed(THD *thd, handlerton *hton) {
 // ---------------------------------------------------------------------------
 
 void MariaDBTxn::buffer_put(const uint8_t *key, size_t klen,
-                            const uint8_t *val, size_t vlen) {
-  if (!snap_) {
+                            const uint8_t *val, size_t vlen,
+                            bool guard_absent) {
+  if (!snap_ && !deferred_insert_) {
     snap_.emplace(db_->snapshot());
   }
 
@@ -58,11 +59,11 @@ void MariaDBTxn::buffer_put(const uint8_t *key, size_t klen,
   lookup_[k] = v;
 
   // Append to ordered log.
-  ops_.push_back(Op{Op::Put, std::move(k), std::move(v)});
+  ops_.push_back(Op{Op::Put, std::move(k), std::move(v), guard_absent});
 }
 
 void MariaDBTxn::buffer_del(const uint8_t *key, size_t klen) {
-  if (!snap_) {
+  if (!snap_ && !deferred_insert_) {
     snap_.emplace(db_->snapshot());
   }
 
@@ -72,7 +73,13 @@ void MariaDBTxn::buffer_del(const uint8_t *key, size_t klen) {
   lookup_[k] = std::nullopt;
 
   // Append to ordered log.
-  ops_.push_back(Op{Op::Del, std::move(k), {}});
+  ops_.push_back(Op{Op::Del, std::move(k), {}, false});
+}
+
+bool MariaDBTxn::buffered_key_present(const uint8_t *key, size_t klen) {
+  if (lookup_.empty()) { return false; }
+  auto it = lookup_.find(std::vector<uint8_t>(key, key + klen));
+  return it != lookup_.end() && it->second.has_value();
 }
 
 // ---------------------------------------------------------------------------
@@ -252,14 +259,20 @@ int MariaDBTxn::commit(THD * /*thd*/, bool all) {
     return 0;
   }
 
+  const bool deferred = deferred_insert_;
   try {
-    // Build WritePlan from snapshot + replay ops in insertion order.
-    bytecask::WritePlan plan{std::move(*snap_)};
+    // Build the WritePlan and replay ops in insertion order. A deferred
+    // INSERT has no snapshot — its ensure_absent guards do the dup check.
+    bytecask::WritePlan plan = snap_ ? bytecask::WritePlan{std::move(*snap_)}
+                                     : bytecask::WritePlan{};
     snap_.reset();
 
     for (const auto &op : ops_) {
       switch (op.kind) {
       case Op::Put:
+        if (op.guard_absent) {
+          plan.ensure_absent(as_view(op.key));
+        }
         plan.put(as_view(op.key), as_view(op.val));
         break;
       case Op::Del:
@@ -273,6 +286,12 @@ int MariaDBTxn::commit(THD * /*thd*/, bool all) {
     if (!committed) {
       revert_row_count_deltas();
       reset();
+      if (deferred) {
+        // Snapshot-less plan: the only precondition is ensure_absent, so a
+        // conflict is a duplicate primary key.
+        my_error(ER_DUP_ENTRY, MYF(0), "", "PRIMARY");
+        return HA_ERR_FOUND_DUPP_KEY;
+      }
       my_error(ER_LOCK_DEADLOCK, MYF(0));
       return HA_ERR_LOCK_DEADLOCK;
     }
@@ -297,6 +316,7 @@ void MariaDBTxn::rollback(THD * /*thd*/, bool all) {
     revert_row_count_deltas();
     ops_.clear();
     lookup_.clear();
+    deferred_insert_ = false;
     registered_stmt_ = false;
     return;
   }
@@ -309,6 +329,7 @@ void MariaDBTxn::reset() {
   ops_.clear();
   lookup_.clear();
   row_count_deltas_.clear();
+  deferred_insert_ = false;
   registered_stmt_ = false;
   registered_all_ = false;
   bulk_reset();

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -43,6 +43,9 @@ public:
     Kind kind;
     std::vector<uint8_t> key;
     std::vector<uint8_t> val;  // empty for Del
+    // Put only: emit ensure_absent(key) into the WritePlan before the put.
+    // Used by the deferred INSERT path to carry the PK dup check to commit.
+    bool guard_absent{false};
   };
 
   // RYOW lookup type: nullopt = tombstone (deleted within this txn).
@@ -164,8 +167,21 @@ public:
   // -------------------------------------------------------------------
 
   void buffer_put(const uint8_t *key, size_t klen,
-                  const uint8_t *val, size_t vlen);
+                  const uint8_t *val, size_t vlen,
+                  bool guard_absent = false);
   void buffer_del(const uint8_t *key, size_t klen);
+
+  // Enter deferred-dup-check mode for a plain autocommit INSERT: no snapshot
+  // is acquired, and commit() builds a snapshot-less WritePlan whose
+  // ensure_absent guards (see Op::guard_absent) carry the PK dup check.
+  // A commit conflict on such a plan is reported as HA_ERR_FOUND_DUPP_KEY.
+  // Cleared by reset() at commit/rollback.
+  void begin_deferred_insert() { deferred_insert_ = true; }
+
+  // In-memory presence probe against the write buffer only (no snapshot, no
+  // DB access). Used by the deferred INSERT path to catch duplicates within
+  // the same statement.
+  bool buffered_key_present(const uint8_t *key, size_t klen);
 
   // -------------------------------------------------------------------
   // RYOW reads
@@ -286,6 +302,9 @@ private:
 
   bool registered_stmt_{false};
   bool registered_all_{false};
+
+  // Set by begin_deferred_insert(); see that method. Reset by reset().
+  bool deferred_insert_{false};
 
   // Bulk-copy mode state (see begin_bulk_copy). Isolated from ops_/lookup_.
   bool bulk_copy_mode_{false};

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -480,6 +480,26 @@ bool ha_bytecaskdb::is_alter_copy_target() const {
 // write_row() — INSERT with duplicate PK detection
 // ---------------------------------------------------------------------------
 
+bool ha_bytecaskdb::has_unique_secondary_index() const {
+  for (const auto &ix : indexes_) {
+    if (ix.is_unique) { return true; }
+  }
+  return false;
+}
+
+// True when the current statement is a plain autocommit INSERT (no BEGIN, no
+// autocommit=0, not INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE). Such
+// a statement can defer its PK duplicate check to commit via an ensure_absent
+// guard instead of an eager per-row DB probe + snapshot.
+bool ha_bytecaskdb::stmt_allows_deferred_dupcheck() const {
+#ifdef PLUGIN_TESTING
+  return false;
+#else
+  return thd_sql_command(ha_thd()) == SQLCOM_INSERT &&
+         !thd_test_options(ha_thd(), OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+#endif
+}
+
 int ha_bytecaskdb::write_row(const uchar *buf) {
   if (!g_db) { return HA_ERR_GENERIC; }
 
@@ -510,12 +530,31 @@ int ha_bytecaskdb::write_row(const uchar *buf) {
   auto &val = encode_row_buf_;
   encode_row_into(val, table, buf, schema_version_);
 
+  // Deferred PK dup check: a plain autocommit INSERT on a PK-only-unique table
+  // does not need to probe the DB (or take a snapshot) per row. The commit-time
+  // WritePlan carries an ensure_absent guard per PK instead; a duplicate then
+  // surfaces as HA_ERR_FOUND_DUPP_KEY from commit(). Within-statement duplicates
+  // are still caught eagerly against the in-memory write buffer below.
+  // INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE need the per-row verdict
+  // (dupcheck_eager_), and a UNIQUE secondary index needs the eager snapshot
+  // path, so both fall through to the classic check.
+  const bool defer_dup =
+      !no_pk && !dupcheck_eager_ && !has_unique_secondary_index() &&
+      stmt_allows_deferred_dupcheck();
+
   // PK-less rows can't collide on the primary key (synthetic rowids are
-  // monotonic), so skip the dup check there. For PK tables, eager dup check.
-  if (!no_pk && txn->exists(key.data(), key.size())) {
-    errkey = saved_errkey_ = table->s->primary_key;
-    return HA_ERR_FOUND_DUPP_KEY;
+  // monotonic), so skip the dup check there. For PK tables, eager dup check
+  // unless deferred (buffer-only probe catches same-statement duplicates).
+  if (!no_pk) {
+    const bool dup = defer_dup
+                         ? txn->buffered_key_present(key.data(), key.size())
+                         : txn->exists(key.data(), key.size());
+    if (dup) {
+      errkey = saved_errkey_ = table->s->primary_key;
+      return HA_ERR_FOUND_DUPP_KEY;
+    }
   }
+  if (defer_dup) { txn->begin_deferred_insert(); }
 
   // Check unique secondary index constraints.
   if (!indexes_.empty()) {
@@ -548,8 +587,10 @@ int ha_bytecaskdb::write_row(const uchar *buf) {
     }
   }
 
-  // Buffer primary key operation.
-  txn->buffer_put(key.data(), key.size(), val.data(), val.size());
+  // Buffer primary key operation. In deferred mode the PK carries an
+  // ensure_absent guard applied at commit.
+  txn->buffer_put(key.data(), key.size(), val.data(), val.size(),
+                  /*guard_absent=*/defer_dup);
 
   FAULT_INJECTION(plugin_after_pk_buffer);
 
@@ -952,6 +993,15 @@ int ha_bytecaskdb::extra(enum ha_extra_function operation) {
       break;
     case HA_EXTRA_NO_KEYREAD:
       keyread_only_ = false;
+      break;
+    case HA_EXTRA_IGNORE_DUP_KEY:      // INSERT IGNORE, ON DUPLICATE KEY UPDATE
+    case HA_EXTRA_WRITE_CAN_REPLACE:   // REPLACE
+    case HA_EXTRA_INSERT_WITH_UPDATE:  // ON DUPLICATE KEY UPDATE
+      dupcheck_eager_ = true;
+      break;
+    case HA_EXTRA_NO_IGNORE_DUP_KEY:
+    case HA_EXTRA_WRITE_CANNOT_REPLACE:
+      dupcheck_eager_ = false;
       break;
     case HA_EXTRA_END_COPY:
       // Belt-and-suspenders: end_bulk_insert normally does the final flush.

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -288,6 +288,21 @@ private:
   // index path skips the secondary→PK row fetch.
   bool keyread_only_ = false;
 
+  // Set by extra(HA_EXTRA_IGNORE_DUP_KEY / WRITE_CAN_REPLACE / INSERT_WITH_UPDATE),
+  // cleared by the matching NO_IGNORE_DUP_KEY / WRITE_CANNOT_REPLACE. When true
+  // the statement needs a per-row HA_ERR_FOUND_DUPP_KEY verdict from write_row
+  // (INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE) and the eager dup check
+  // must run; when false a plain autocommit INSERT can defer it to commit.
+  bool dupcheck_eager_ = false;
+
+  // True iff the table has at least one UNIQUE secondary index. Deferred dup
+  // checking only applies to PK-only uniqueness, so this forces the eager path.
+  [[nodiscard]] bool has_unique_secondary_index() const;
+
+  // True when the current statement is a plain autocommit INSERT that may
+  // defer its PK dup check to commit. Always false under PLUGIN_TESTING.
+  [[nodiscard]] bool stmt_allows_deferred_dupcheck() const;
+
   static void write_table_id_prefix(uint8_t *buf4, uint32_t table_id);
 };
 

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
@@ -350,13 +350,18 @@ inline void thd_set_ha_data(THD *thd, handlerton *hton, void *data) {
   thd->ha_data[hton->slot] = data;
 }
 
-// Stub: my_error / MYF — no-op in tests.
+// Stub: my_error / MYF — records the last error code (no message formatting)
+// so tests can assert on which ER_* a code path actually raised.
 #define MYF(x) (x)
-inline void my_error(int /*error*/, unsigned long /*flags*/, ...) {}
+inline int g_stub_last_my_error_code = 0;
+inline void my_error(int error, unsigned long /*flags*/, ...) {
+  g_stub_last_my_error_code = error;
+}
 
 // MariaDB error codes.
 #define ER_LOCK_DEADLOCK 1213
 #define ER_DUP_ENTRY 1062
+#define ER_DUP_ENTRY_WITH_KEY_NAME 1586
 
 // Stubs for key_copy / key_restore — these are MariaDB server functions.
 // For proof tests, key_copy must actually copy field data into the key buffer

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
@@ -87,6 +87,11 @@ enum ha_extra_function {
   HA_EXTRA_NO_KEYREAD = 2,
   HA_EXTRA_END_COPY = 3,
   HA_EXTRA_ABORT_COPY = 4,
+  HA_EXTRA_IGNORE_DUP_KEY = 5,
+  HA_EXTRA_NO_IGNORE_DUP_KEY = 6,
+  HA_EXTRA_WRITE_CAN_REPLACE = 7,
+  HA_EXTRA_WRITE_CANNOT_REPLACE = 8,
+  HA_EXTRA_INSERT_WITH_UPDATE = 9,
 };
 
 // MariaDB key read functions.
@@ -351,6 +356,7 @@ inline void my_error(int /*error*/, unsigned long /*flags*/, ...) {}
 
 // MariaDB error codes.
 #define ER_LOCK_DEADLOCK 1213
+#define ER_DUP_ENTRY 1062
 
 // Stubs for key_copy / key_restore — these are MariaDB server functions.
 // For proof tests, key_copy must actually copy field data into the key buffer

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -309,6 +309,49 @@ TEST_CASE_METHOD(MariaDBTxnFixture, "MariaDBTxn commit rollback", "[txn][commit]
 }
 
 // =========================================================================
+// Deferred INSERT dup-check (P3): commit-time ensure_absent conflict
+// =========================================================================
+
+TEST_CASE_METHOD(MariaDBTxnFixture, "MariaDBTxn deferred insert dup check",
+                  "[txn][commit][deferred]") {
+  auto pk = make_key("user:1");
+  auto val1 = make_value("alice");
+  auto val2 = make_value("mallory");
+
+  // Commit the row via a first, ordinary (non-deferred) transaction so it's
+  // durable before the deferred-mode transaction under test tries to insert
+  // the same PK.
+  {
+    auto seed = create_txn();
+    THD thd{};
+    seed->buffer_put(pk.data(), pk.size(), val1.data(), val1.size());
+    REQUIRE(seed->commit(&thd, true) == 0);
+  }
+
+  SECTION("commit-time conflict returns HA_ERR_FOUND_DUPP_KEY and raises "
+          "ER_DUP_ENTRY_WITH_KEY_NAME") {
+    auto txn = create_txn();
+    THD thd{};
+
+    g_stub_last_my_error_code = 0;
+
+    txn->begin_deferred_insert();
+    txn->buffer_put(pk.data(), pk.size(), val2.data(), val2.size(),
+                    /*guard_absent=*/true);
+
+    int rc = txn->commit(&thd, true);
+
+    REQUIRE(rc == HA_ERR_FOUND_DUPP_KEY);
+    // ER_DUP_ENTRY's second format placeholder is an integer key index, not
+    // a string — passing a key name there is undefined behavior on the
+    // varargs call and produces a garbled message at runtime. Regression
+    // coverage for that bug: assert the code actually raised is the
+    // two-string variant the (value, key-name) args match.
+    REQUIRE(g_stub_last_my_error_code == ER_DUP_ENTRY_WITH_KEY_NAME);
+  }
+}
+
+// =========================================================================
 // Edge Cases and Error Handling
 // =========================================================================
 


### PR DESCRIPTION
## Summary

Defers the primary-key duplicate check for plain autocommit `INSERT`s on a
PK-only-unique table from an eager `txn->exists(pk)` probe against the live
DB to a commit-time `ensure_absent` guard on a snapshot-less `WritePlan`.
The eager probe forced a thread-local read-snapshot refresh and a
`db_->snapshot()` per statement, which — on this workload — triggers a
synchronous free of the previous `EngineState` generation on the calling
thread: measured at ~28–34% of the query thread's on-CPU time in an
`oltp_insert` profile.

Within-statement duplicates are still caught eagerly via an in-memory-only
probe against the transaction's own write buffer
(`MariaDBTxn::buffered_key_present`) — no DB access, no snapshot.

`INSERT IGNORE`, `REPLACE`, `INSERT ... ON DUPLICATE KEY UPDATE`,
multi-statement transactions, and the PK-changing branch of `update_row`
are unaffected — they keep the eager path. No on-disk format, catalog, or
recovery changes.

## Second commit: fixes a bug the first commit's own message flagged

The first commit's message documented a known, unfixed issue: the
commit-time duplicate-key error used `my_error(ER_DUP_ENTRY, MYF(0), "",
"PRIMARY")`, but `ER_DUP_ENTRY`'s second format placeholder is an integer
key index, not a string — undefined behavior on the varargs call,
confirmed live to print `Duplicate entry '' for key -1177085216`.

The second commit swaps in `ER_DUP_ENTRY_WITH_KEY_NAME` (1586, format
`"Duplicate entry '%s' for key '%s'"`), which matches the `(value,
key-name)` args already being passed, and adds a regression test that
drives `MariaDBTxn::commit()`'s deferred path directly and asserts the
*error code* raised — not just the `HA_ERR_FOUND_DUPP_KEY` return value.
Previously `my_error()` was a pure no-op in the test harness, so this bug
shipped through 1167+1003 passing assertions without a single one
exercising it. Confirmed the new test fails (`1062 != 1586`) against the
pre-fix code and passes against the fix.

## Testing

All three plugin test binaries rebuilt and run clean in this session:

| Binary | Before fix | After fix |
|---|---|---|
| `mariadb_txn_tests` | 69/69 | **72/72** (+1 case / +3 assertions) |
| `mariadb_plugin_tests` | 1167/1167 | 1167/1167 |
| `mariadb_proof_tests` | 1003/1003 (202 cases) | 1003/1003 (202 cases) |

Live smoke test against a real `mariadbd` + the built plugin, after the fix:

- Plain duplicate `INSERT` → `ERROR 1586 (23000): Duplicate entry '' for
  key 'PRIMARY'` (row unchanged) — correct message, vs. the garbled one
  before the fix.
- `INSERT IGNORE` on a duplicate → no-op (`ROW_COUNT()=0`).
- Multi-row `INSERT` with a duplicate in the middle → fails atomically,
  no partial rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
