### PR TITLE
MariaDB plugin correctness fixes ahead of the steady-state benchmark

### DIFF
--- a/bytecaskdb-mariadb-plugin/README.md
+++ b/bytecaskdb-mariadb-plugin/README.md
@@ -4,6 +4,18 @@
 
 A MariaDB storage engine plugin that exposes ByteCaskDB as a SQL-accessible table engine. Supports full DML (INSERT, UPDATE, DELETE, SELECT), secondary indexes, transactions with savepoints, and bulk loading.
 
+## Differences from InnoDB
+
+Read this before pointing an application written for InnoDB at the engine.
+
+- **Optimistic concurrency, not locking.** Nothing blocks. A transaction reads from a snapshot taken at its first read or write and buffers its writes in memory. At `COMMIT`, a write to a row that another transaction changed since that snapshot fails the whole transaction with error 1213 (`ER_LOCK_DEADLOCK`). The server does not retry it; the application must re-read and redo the transaction. Under contention on hot rows, expect 1213 as a normal outcome rather than waiting.
+- **`SELECT ... FOR UPDATE` and `LOCK IN SHARE MODE` are plain snapshot reads.** They take no locks and register no conflict guard, so a read-then-write pattern that relies on `FOR UPDATE` to serialise is only protected for rows the transaction actually writes. Write skew between two transactions that read overlapping rows and write disjoint ones is possible.
+- **Foreign keys are not enforced.** `FOREIGN KEY` clauses are accepted, stored, and listed in `information_schema`, so DDL round-trips through dump and restore, but no referential check runs on `INSERT`, `UPDATE` or `DELETE`, and there are no cascades.
+- **Transactions are buffered in RAM until commit.** A transaction that modifies millions of rows holds all of them in memory. `ALTER TABLE ... ALGORITHM=COPY` and `CREATE INDEX` are exempt: they flush in batches.
+- **Long-lived snapshots defer vacuum.** `mysqldump --single-transaction` and any long transaction pin the data files they can see; space from overwritten or deleted rows is reclaimed only after they finish.
+- **Every table's key directory lives in memory.** Budget roughly 50 bytes per row per index (primary and secondary) of resident memory, in addition to MariaDB's own.
+- **Not supported:** `FULLTEXT` and `SPATIAL` indexes, `LOCK TABLES` blocking semantics, `HANDLER`, `INSERT DELAYED`, table-level lock priorities, `CHECKSUM TABLE ... QUICK`.
+
 ## Examples
 
 Ready-to-run Docker Compose setups demonstrating ByteCaskDB as a drop-in storage engine:

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_plugin.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_plugin.cc
@@ -474,13 +474,14 @@ std::optional<uint32_t> catalog_lookup_table_id(const char *name) {
   return std::nullopt;
 }
 
-const TableMeta *catalog_lookup_meta(uint32_t table_id) {
+bool catalog_copy_meta(uint32_t table_id, TableMeta &out) {
   std::lock_guard<std::mutex> lk{s_catalog_mu};
   auto it = s_id_to_meta.find(table_id);
-  if (it != s_id_to_meta.end()) {
-    return &it->second;
+  if (it == s_id_to_meta.end()) {
+    return false;
   }
-  return nullptr;
+  out = it->second;
+  return true;
 }
 
 } // namespace bytecaskdb

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_plugin.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_plugin.cc
@@ -738,7 +738,9 @@ static int bytecaskdb_init(void *p) {
   hton->close_connection         = bytecaskdb_close_connection;
   hton->start_consistent_snapshot = bytecaskdb_start_consistent_snapshot;
   hton->show_status              = bytecaskdb_show_status;
-  hton->flags                    = HTON_SUPPORTS_FOREIGN_KEYS;
+  // No HTON_SUPPORTS_FOREIGN_KEYS: FOREIGN KEY clauses are recorded in the
+  // catalog for DDL round-trips but nothing is enforced (see README).
+  hton->flags                    = 0;
   hton->savepoint_offset         = sizeof(uint32_t);
   hton->savepoint_set            = bytecaskdb_savepoint_set;
   hton->savepoint_rollback       = bytecaskdb_savepoint_rollback;

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -35,6 +35,8 @@ void MariaDBTxn::begin_if_needed(THD *thd, handlerton *hton) {
   if (!registered_stmt_) {
     trans_register_ha(thd, false, hton, 0);
     registered_stmt_ = true;
+    stmt_ops_mark_ = ops_.size();
+    stmt_row_count_deltas_ = row_count_deltas_;
   }
 }
 
@@ -328,10 +330,10 @@ void MariaDBTxn::rollback(THD * /*thd*/, bool all) {
   bulk_reset();
 
   if (!all && registered_all_) {
-    // Statement rollback within session txn — clear buffer (conservative).
-    revert_row_count_deltas();
-    ops_.clear();
-    lookup_.clear();
+    // Statement rollback within a session transaction: undo only this
+    // statement. Earlier statements stay buffered for the session commit.
+    restore_row_count_deltas(stmt_row_count_deltas_);
+    truncate_ops(stmt_ops_mark_);
     deferred_insert_ = false;
     registered_stmt_ = false;
     return;
@@ -340,11 +342,42 @@ void MariaDBTxn::rollback(THD * /*thd*/, bool all) {
   reset();
 }
 
+void MariaDBTxn::truncate_ops(std::size_t mark) {
+  if (mark > ops_.size()) { mark = ops_.size(); }
+  ops_.resize(mark);
+  lookup_.clear();
+  for (const auto &op : ops_) {
+    if (op.kind == Op::Put)
+      lookup_[op.key] = op.val;
+    else
+      lookup_[op.key] = std::nullopt;
+  }
+}
+
+void MariaDBTxn::restore_row_count_deltas(const RowCountDeltas &saved) {
+  for (auto &[table_id, entry] : row_count_deltas_) {
+    int64_t saved_delta = 0;
+    if (auto it = saved.find(table_id); it != saved.end()) {
+      saved_delta = it->second.delta;
+    }
+    const int64_t undo = entry.delta - saved_delta;
+    if (undo == 0) { continue; }
+    if (entry.counter) {
+      entry.counter->fetch_add(-undo);
+    } else {
+      catalog_row_count_add(table_id, -undo);
+    }
+  }
+  row_count_deltas_ = saved;
+}
+
 void MariaDBTxn::reset() {
   snap_.reset();
   ops_.clear();
   lookup_.clear();
   row_count_deltas_.clear();
+  stmt_ops_mark_ = 0;
+  stmt_row_count_deltas_.clear();
   deferred_insert_ = false;
   registered_stmt_ = false;
   registered_all_ = false;
@@ -368,16 +401,7 @@ void MariaDBTxn::track_row_count_delta(uint32_t table_id,
 }
 
 void MariaDBTxn::revert_row_count_deltas() {
-  for (auto &[table_id, entry] : row_count_deltas_) {
-    if (entry.delta != 0) {
-      if (entry.counter) {
-        entry.counter->fetch_add(-entry.delta);
-      } else {
-        catalog_row_count_add(table_id, -entry.delta);
-      }
-    }
-  }
-  row_count_deltas_.clear();
+  restore_row_count_deltas({});
 }
 
 // ---------------------------------------------------------------------------
@@ -475,15 +499,7 @@ void MariaDBTxn::savepoint_set(void *sv) {
 }
 
 void MariaDBTxn::savepoint_rollback(void *sv) {
-  uint32_t mark = *static_cast<const uint32_t *>(sv);
-  ops_.resize(mark);
-  lookup_.clear();
-  for (const auto &op : ops_) {
-    if (op.kind == Op::Put)
-      lookup_[op.key] = op.val;
-    else
-      lookup_[op.key] = std::nullopt;
-  }
+  truncate_ops(*static_cast<const uint32_t *>(sv));
 }
 
 void MariaDBTxn::savepoint_release(void * /*sv*/) {

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -13,6 +13,7 @@
 #include "sql_priv.h"
 #include "mysqld_error.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 
@@ -208,14 +209,11 @@ std::unique_ptr<MariaDBTxn::MergeIterator> MariaDBTxn::riter_index_prefix(
 
   std::vector<uint8_t> lo_vec(lo, lo + lo_len);
   std::vector<uint8_t> hi_vec(hi, hi + hi_len);
-  auto buf_it = lookup_.upper_bound(hi_vec);
-  if (buf_it != lookup_.begin()) {
-    --buf_it;
-  }
+  auto buf_it = reverse_buffer_start(hi_vec);
 
   return std::make_unique<MergeIterator>(
-      std::move(snap_it), buf_it, lookup_.end(), std::move(lo_vec),
-      table_id, index_id);
+      std::move(snap_it), buf_it, lookup_.begin(), lookup_.end(),
+      std::move(lo_vec), table_id, index_id);
 }
 
 std::unique_ptr<MariaDBTxn::MergeIterator> MariaDBTxn::riter_prefix(
@@ -234,13 +232,20 @@ std::unique_ptr<MariaDBTxn::MergeIterator> MariaDBTxn::riter_prefix(
 
   std::vector<uint8_t> lo_vec(lo, lo + lo_len);
   std::vector<uint8_t> hi_vec(hi, hi + hi_len);
-  auto buf_it = lookup_.upper_bound(hi_vec);
-  if (buf_it != lookup_.begin()) {
-    --buf_it;
-  }
+  auto buf_it = reverse_buffer_start(hi_vec);
 
   return std::make_unique<MergeIterator>(
-      std::move(snap_it), buf_it, lookup_.end(), std::move(lo_vec), table_id);
+      std::move(snap_it), buf_it, lookup_.begin(), lookup_.end(),
+      std::move(lo_vec), table_id);
+}
+
+// Largest buffered key <= hi, or end() when every buffered key is above hi.
+// Mirrors rkeys_from(hi) on the snapshot side.
+MariaDBTxn::LookupMap::const_iterator
+MariaDBTxn::reverse_buffer_start(const std::vector<uint8_t> &hi) const {
+  auto it = lookup_.upper_bound(hi);
+  if (it == lookup_.begin()) { return lookup_.end(); }
+  return --it;
 }
 
 // ---------------------------------------------------------------------------
@@ -522,6 +527,7 @@ MariaDBTxn::MergeIterator::MergeIterator(
     : snap_fwd_(std::move(snap_it)),
       reverse_(false),
       buf_it_(buf_it),
+      buf_begin_(buf_it),
       buf_end_(buf_end),
       bound_(std::move(hi)),
       table_id_(table_id) {
@@ -538,6 +544,7 @@ MariaDBTxn::MergeIterator::MergeIterator(
     : snap_key_fwd_(std::move(snap_it)),
       reverse_(false),
       buf_it_(buf_it),
+      buf_begin_(buf_it),
       buf_end_(buf_end),
       bound_(std::move(hi)),
       table_id_(table_id),
@@ -550,12 +557,14 @@ MariaDBTxn::MergeIterator::MergeIterator(
 MariaDBTxn::MergeIterator::MergeIterator(
     std::optional<bytecask::ReverseEntryIterator> snap_it,
     LookupMap::const_iterator buf_it,
+    LookupMap::const_iterator buf_begin,
     LookupMap::const_iterator buf_end,
     std::vector<uint8_t> lo,
     uint32_t table_id)
     : snap_rev_(std::move(snap_it)),
       reverse_(true),
       buf_it_(buf_it),
+      buf_begin_(buf_begin),
       buf_end_(buf_end),
       bound_(std::move(lo)),
       table_id_(table_id) {
@@ -566,12 +575,14 @@ MariaDBTxn::MergeIterator::MergeIterator(
 MariaDBTxn::MergeIterator::MergeIterator(
     std::optional<bytecask::ReverseKeyIterator> snap_it,
     LookupMap::const_iterator buf_it,
+    LookupMap::const_iterator buf_begin,
     LookupMap::const_iterator buf_end,
     std::vector<uint8_t> lo,
     uint32_t table_id, uint16_t index_id)
     : snap_key_rev_(std::move(snap_it)),
       reverse_(true),
       buf_it_(buf_it),
+      buf_begin_(buf_begin),
       buf_end_(buf_end),
       bound_(std::move(lo)),
       table_id_(table_id),
@@ -668,105 +679,100 @@ void MariaDBTxn::MergeIterator::load_snap_current() {
   snap_valid_ = true;
 }
 
+void MariaDBTxn::MergeIterator::buf_step() {
+  if (!reverse_) {
+    ++buf_it_;
+    return;
+  }
+  if (buf_it_ == buf_begin_) {
+    buf_it_ = buf_end_;
+  } else {
+    --buf_it_;
+  }
+}
+
+bool MariaDBTxn::MergeIterator::buf_candidate_valid() const {
+  if (buf_it_ == buf_end_) return false;
+  const auto &bk = buf_it_->first;
+  if (!reverse_ && !bound_.empty() &&
+      bk.size() >= bound_.size() &&
+      std::memcmp(bk.data(), bound_.data(), bound_.size()) >= 0) {
+    return false;
+  }
+  if (use_index_filter_) {
+    return key_belongs_to_index(bk.data(), bk.size(), table_id_, index_id_);
+  }
+  return key_belongs_to_table(bk.data(), bk.size(), table_id_);
+}
+
+void MariaDBTxn::MergeIterator::emit_buf() {
+  cur_key_ = buf_it_->first;
+  assign_bytes(cur_val_, buf_it_->second.value());
+  buf_step();
+  valid_ = true;
+}
+
+void MariaDBTxn::MergeIterator::emit_snap() {
+  cur_key_.assign(snap_key_ptr_, snap_key_ptr_ + snap_key_len_);
+  assign_bytes(cur_val_, snap_val_ptr_, snap_val_len_);
+  snap_step();
+  load_snap_current();
+  valid_ = true;
+}
+
 void MariaDBTxn::MergeIterator::advance() {
   valid_ = false;
 
   for (;;) {
-    bool buf_valid = (buf_it_ != buf_end_);
-    if (buf_valid && !reverse_ && !bound_.empty()) {
-      const auto &bk = buf_it_->first;
-      if (bk.size() >= bound_.size() &&
-          std::memcmp(bk.data(), bound_.data(), bound_.size()) >= 0) {
-        buf_valid = false;
-      }
-    }
-    if (buf_valid) {
-      if (use_index_filter_) {
-        if (!key_belongs_to_index(buf_it_->first.data(),
-                                  buf_it_->first.size(),
-                                  table_id_, index_id_)) {
-          buf_valid = false;
-        }
-      } else {
-        if (!key_belongs_to_table(buf_it_->first.data(),
-                                  buf_it_->first.size(), table_id_)) {
-          buf_valid = false;
-        }
-      }
-    }
+    const bool buf_valid = buf_candidate_valid();
 
     if (!snap_valid_ && !buf_valid) {
       return;
     }
 
-    if (!snap_valid_ && buf_valid) {
-      if (buf_it_->second.has_value()) {
-        cur_key_ = buf_it_->first;
-        assign_bytes(cur_val_, buf_it_->second.value());
-        ++buf_it_;
-        valid_ = true;
-        return;
-      }
-      ++buf_it_;
+    if (!snap_valid_) {
+      if (buf_it_->second.has_value()) { emit_buf(); return; }
+      buf_step();  // tombstone with nothing to suppress
       continue;
     }
 
-    if (snap_valid_ && !buf_valid) {
-      cur_key_.assign(snap_key_ptr_, snap_key_ptr_ + snap_key_len_);
-      assign_bytes(cur_val_, snap_val_ptr_, snap_val_len_);
-      snap_step();
-      load_snap_current();
-      valid_ = true;
+    if (!buf_valid) {
+      emit_snap();
       return;
     }
 
-    // Both have data — compare keys.
+    // Both sides have a candidate: lexicographic compare, shorter-is-less.
     const auto &bk = buf_it_->first;
-    int cmp;
-    if (bk.size() == snap_key_len_) {
-      cmp = std::memcmp(bk.data(), snap_key_ptr_, bk.size());
-    } else if (bk.size() < snap_key_len_) {
-      cmp = std::memcmp(bk.data(), snap_key_ptr_, bk.size());
-      if (cmp == 0) cmp = -1;
-    } else {
-      cmp = std::memcmp(bk.data(), snap_key_ptr_, snap_key_len_);
-      if (cmp == 0) cmp = 1;
-    }
-
-    if (cmp < 0) {
-      if (buf_it_->second.has_value()) {
-        cur_key_ = bk;
-        assign_bytes(cur_val_, buf_it_->second.value());
-        ++buf_it_;
-        valid_ = true;
-        return;
-      }
-      ++buf_it_;
-      continue;
+    const size_t n = std::min(bk.size(), snap_key_len_);
+    int cmp = std::memcmp(bk.data(), snap_key_ptr_, n);
+    if (cmp == 0) {
+      cmp = (bk.size() < snap_key_len_) ? -1
+          : (bk.size() > snap_key_len_) ?  1 : 0;
     }
 
     if (cmp == 0) {
-      bool has_val = buf_it_->second.has_value();
+      // Same key on both sides: the buffer's version wins; a tombstone
+      // hides the snapshot entry.
+      const bool has_val = buf_it_->second.has_value();
       if (has_val) {
         cur_key_ = bk;
         assign_bytes(cur_val_, buf_it_->second.value());
       }
-      ++buf_it_;
+      buf_step();
       snap_step();
       load_snap_current();
-      if (has_val) {
-        valid_ = true;
-        return;
-      }
+      if (has_val) { valid_ = true; return; }
       continue;
     }
 
-    // cmp > 0
-    cur_key_.assign(snap_key_ptr_, snap_key_ptr_ + snap_key_len_);
-    assign_bytes(cur_val_, snap_val_ptr_, snap_val_len_);
-    snap_step();
-    load_snap_current();
-    valid_ = true;
+    // Forward emits the smaller key first; reverse emits the larger.
+    const bool buf_first = reverse_ ? (cmp > 0) : (cmp < 0);
+    if (buf_first) {
+      if (buf_it_->second.has_value()) { emit_buf(); return; }
+      buf_step();
+      continue;
+    }
+    emit_snap();
     return;
   }
 }

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -42,12 +42,24 @@ void MariaDBTxn::begin_if_needed(THD *thd, handlerton *hton) {
 // Write buffering
 // ---------------------------------------------------------------------------
 
-void MariaDBTxn::buffer_put(const uint8_t *key, size_t klen,
-                            const uint8_t *val, size_t vlen,
-                            bool guard_absent) {
+// Pins the OCC snapshot for this statement/transaction on first use. Every
+// read and every buffered write goes through here so that the snapshot
+// predates any value the statement acts on: the engine's commit-time
+// write-write check compares against this snapshot, and a key that another
+// transaction committed after it counts as a conflict. Taking the snapshot
+// later (at the first write) would let an autocommit read-modify-write
+// silently overwrite a concurrent commit. Skipped in deferred-INSERT mode,
+// whose commit is snapshot-less by design (see begin_deferred_insert).
+void MariaDBTxn::ensure_snapshot() {
   if (!snap_ && !deferred_insert_) {
     snap_.emplace(db_->snapshot());
   }
+}
+
+void MariaDBTxn::buffer_put(const uint8_t *key, size_t klen,
+                            const uint8_t *val, size_t vlen,
+                            bool guard_absent) {
+  ensure_snapshot();
 
   std::vector<uint8_t> k(key, key + klen);
   std::vector<uint8_t> v;
@@ -63,9 +75,7 @@ void MariaDBTxn::buffer_put(const uint8_t *key, size_t klen,
 }
 
 void MariaDBTxn::buffer_del(const uint8_t *key, size_t klen) {
-  if (!snap_ && !deferred_insert_) {
-    snap_.emplace(db_->snapshot());
-  }
+  ensure_snapshot();
 
   std::vector<uint8_t> k(key, key + klen);
 
@@ -101,6 +111,7 @@ int MariaDBTxn::get(const uint8_t *key, size_t klen, bytecask::Bytes &out) {
     }
   }
 
+  ensure_snapshot();
   try {
     if (snap_) {
       return snap_->get({}, as_view(key, klen), out) ? 1 : 0;
@@ -120,6 +131,7 @@ bool MariaDBTxn::exists(const uint8_t *key, size_t klen) {
     }
   }
 
+  ensure_snapshot();
   try {
     if (snap_) {
       return snap_->contains_key({}, as_view(key, klen));

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -554,6 +554,15 @@ void MariaDBTxn::savepoint_release(void *sv) {
   if (idx < savepoints_.size()) { savepoints_.resize(idx); }
 }
 
+namespace {
+// Lexicographic byte compare; a proper prefix sorts first.
+int lex_compare(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen) {
+  const int c = std::memcmp(a, b, std::min(alen, blen));
+  if (c != 0) return c;
+  return (alen < blen) ? -1 : (alen > blen) ? 1 : 0;
+}
+}  // namespace
+
 // ---------------------------------------------------------------------------
 // MergeIterator
 //
@@ -711,11 +720,9 @@ void MariaDBTxn::MergeIterator::load_snap_current() {
     }
   }
 
-  if (!reverse_ && !bound_.empty()) {
-    if (klen >= bound_.size() &&
-        std::memcmp(kp, bound_.data(), bound_.size()) >= 0) {
-      return;
-    }
+  if (!reverse_ && !bound_.empty() &&
+      lex_compare(kp, klen, bound_.data(), bound_.size()) >= 0) {
+    return;
   }
 
   snap_key_ptr_ = kp;
@@ -739,8 +746,7 @@ bool MariaDBTxn::MergeIterator::buf_candidate_valid() const {
   if (buf_it_ == buf_end_) return false;
   const auto &bk = buf_it_->first;
   if (!reverse_ && !bound_.empty() &&
-      bk.size() >= bound_.size() &&
-      std::memcmp(bk.data(), bound_.data(), bound_.size()) >= 0) {
+      lex_compare(bk.data(), bk.size(), bound_.data(), bound_.size()) >= 0) {
     return false;
   }
   if (use_index_filter_) {
@@ -785,14 +791,9 @@ void MariaDBTxn::MergeIterator::advance() {
       return;
     }
 
-    // Both sides have a candidate: lexicographic compare, shorter-is-less.
+    // Both sides have a candidate.
     const auto &bk = buf_it_->first;
-    const size_t n = std::min(bk.size(), snap_key_len_);
-    int cmp = std::memcmp(bk.data(), snap_key_ptr_, n);
-    if (cmp == 0) {
-      cmp = (bk.size() < snap_key_len_) ? -1
-          : (bk.size() > snap_key_len_) ?  1 : 0;
-    }
+    const int cmp = lex_compare(bk.data(), bk.size(), snap_key_ptr_, snap_key_len_);
 
     if (cmp == 0) {
       // Same key on both sides: the buffer's version wins; a tombstone

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -12,6 +12,10 @@
 #include "mysql/plugin.h"
 #include "sql_priv.h"
 #include "mysqld_error.h"
+#ifndef PLUGIN_TESTING
+#undef WITH_WSREP
+#include <mysql/server/private/sql_class.h>  // ER_THD_OR_DEFAULT
+#endif
 
 #include <algorithm>
 #include <cassert>
@@ -252,7 +256,7 @@ MariaDBTxn::reverse_buffer_start(const std::vector<uint8_t> &hi) const {
 // Commit / rollback
 // ---------------------------------------------------------------------------
 
-int MariaDBTxn::commit(THD * /*thd*/, bool all) {
+int MariaDBTxn::commit(THD *thd, bool all) {
   if (bulk_copy_mode_ && (all || !registered_all_)) {
     // Flush any tail rows the copy loop left buffered, then fall through.
     // end_bulk_insert normally does this already; this covers paths that
@@ -303,18 +307,16 @@ int MariaDBTxn::commit(THD * /*thd*/, bool all) {
     bool committed = db_->apply_batch(bytecask::WriteOptions{.sync = true},
                                       std::move(plan)).has_value();
     if (!committed) {
-      revert_row_count_deltas();
-      reset();
       if (deferred) {
         // Snapshot-less plan: the only precondition is ensure_absent, so a
-        // conflict is a duplicate primary key. ER_DUP_ENTRY_WITH_KEY_NAME
-        // (not ER_DUP_ENTRY) takes two strings — "Duplicate entry '%s' for
-        // key '%s'" — matching the (value, key-name) args passed here.
-        // ER_DUP_ENTRY's second placeholder is an integer key index, so
-        // passing "PRIMARY" there is undefined behavior on the varargs call.
-        my_error(ER_DUP_ENTRY_WITH_KEY_NAME, MYF(0), "", "PRIMARY");
+        // conflict is a duplicate primary key.
+        report_deferred_dup_key(thd);
+        revert_row_count_deltas();
+        reset();
         return HA_ERR_FOUND_DUPP_KEY;
       }
+      revert_row_count_deltas();
+      reset();
       my_error(ER_LOCK_DEADLOCK, MYF(0));
       return HA_ERR_LOCK_DEADLOCK;
     }
@@ -340,6 +342,8 @@ void MariaDBTxn::rollback(THD * /*thd*/, bool all) {
     restore_row_count_deltas(stmt_row_count_deltas_);
     truncate_ops(stmt_ops_mark_);
     deferred_insert_ = false;
+    deferred_handler_ = nullptr;
+    deferred_reporter_ = nullptr;
     registered_stmt_ = false;
     return;
   }
@@ -376,6 +380,32 @@ void MariaDBTxn::restore_row_count_deltas(const RowCountDeltas &saved) {
   row_count_deltas_ = saved;
 }
 
+void MariaDBTxn::report_deferred_dup_key(THD *thd) {
+  // ops_ is still intact here; the first guarded key that exists in the
+  // live DB is the one the ensure_absent guard rejected.
+  const std::vector<uint8_t> *dup = nullptr;
+  for (const auto &op : ops_) {
+    if (op.kind != Op::Put || !op.guard_absent) { continue; }
+    bool present = false;
+    try {
+      present = db_->contains_key({}, as_view(op.key));
+    } catch (...) {
+      present = false;
+    }
+    if (present) { dup = &op.key; break; }
+  }
+  if (deferred_reporter_ && dup) {
+    deferred_reporter_(*dup);
+    return;
+  }
+  // No handler (or no identifiable key): same error code and format the
+  // server uses, without a rendered value. ER_DUP_ENTRY's own format takes
+  // a key *index* as its second argument; the server pairs the ER_DUP_ENTRY
+  // code with the WITH_KEY_NAME format for named keys, and so do we.
+  my_printf_error(ER_DUP_ENTRY, ER_THD_OR_DEFAULT(thd, ER_DUP_ENTRY_WITH_KEY_NAME),
+                  MYF(0), "", "PRIMARY");
+}
+
 void MariaDBTxn::reset() {
   snap_.reset();
   ops_.clear();
@@ -384,6 +414,8 @@ void MariaDBTxn::reset() {
   stmt_ops_mark_ = 0;
   stmt_row_count_deltas_.clear();
   deferred_insert_ = false;
+  deferred_handler_ = nullptr;
+  deferred_reporter_ = nullptr;
   registered_stmt_ = false;
   registered_all_ = false;
   bulk_reset();

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -411,6 +411,7 @@ void MariaDBTxn::reset() {
   row_count_deltas_.clear();
   stmt_ops_mark_ = 0;
   stmt_row_count_deltas_.clear();
+  savepoints_.clear();
   deferred_insert_ = false;
   deferred_handler_ = nullptr;
   deferred_reporter_ = nullptr;
@@ -529,15 +530,28 @@ bool MariaDBTxn::bulk_unique_prefix_exists(const uint8_t *prefix,
 // Savepoints
 // ---------------------------------------------------------------------------
 
+// The server hands each savepoint a hton-sized slot (savepoint_offset =
+// sizeof(uint32_t)); it holds an index into savepoints_, whose entry
+// records where the op log stood and what the row counters were.
+
 void MariaDBTxn::savepoint_set(void *sv) {
-  *static_cast<uint32_t *>(sv) = static_cast<uint32_t>(ops_.size());
+  savepoints_.push_back({ops_.size(), row_count_deltas_});
+  *static_cast<uint32_t *>(sv) = static_cast<uint32_t>(savepoints_.size() - 1);
 }
 
 void MariaDBTxn::savepoint_rollback(void *sv) {
-  truncate_ops(*static_cast<const uint32_t *>(sv));
+  const auto idx = *static_cast<const uint32_t *>(sv);
+  if (idx >= savepoints_.size()) { return; }
+  const auto &sp = savepoints_[idx];
+  restore_row_count_deltas(sp.row_count_deltas);
+  truncate_ops(sp.ops_mark);
+  // The savepoint itself survives ROLLBACK TO; later ones are gone.
+  savepoints_.resize(idx + 1);
 }
 
-void MariaDBTxn::savepoint_release(void * /*sv*/) {
+void MariaDBTxn::savepoint_release(void *sv) {
+  const auto idx = *static_cast<const uint32_t *>(sv);
+  if (idx < savepoints_.size()) { savepoints_.resize(idx); }
 }
 
 // ---------------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.cc
@@ -12,10 +12,6 @@
 #include "mysql/plugin.h"
 #include "sql_priv.h"
 #include "mysqld_error.h"
-#ifndef PLUGIN_TESTING
-#undef WITH_WSREP
-#include <mysql/server/private/sql_class.h>  // ER_THD_OR_DEFAULT
-#endif
 
 #include <algorithm>
 #include <cassert>
@@ -256,7 +252,7 @@ MariaDBTxn::reverse_buffer_start(const std::vector<uint8_t> &hi) const {
 // Commit / rollback
 // ---------------------------------------------------------------------------
 
-int MariaDBTxn::commit(THD *thd, bool all) {
+int MariaDBTxn::commit(THD * /*thd*/, bool all) {
   if (bulk_copy_mode_ && (all || !registered_all_)) {
     // Flush any tail rows the copy loop left buffered, then fall through.
     // end_bulk_insert normally does this already; this covers paths that
@@ -310,7 +306,7 @@ int MariaDBTxn::commit(THD *thd, bool all) {
       if (deferred) {
         // Snapshot-less plan: the only precondition is ensure_absent, so a
         // conflict is a duplicate primary key.
-        report_deferred_dup_key(thd);
+        report_deferred_dup_key();
         revert_row_count_deltas();
         reset();
         return HA_ERR_FOUND_DUPP_KEY;
@@ -380,7 +376,7 @@ void MariaDBTxn::restore_row_count_deltas(const RowCountDeltas &saved) {
   row_count_deltas_ = saved;
 }
 
-void MariaDBTxn::report_deferred_dup_key(THD *thd) {
+void MariaDBTxn::report_deferred_dup_key() {
   // ops_ is still intact here; the first guarded key that exists in the
   // live DB is the one the ensure_absent guard rejected.
   const std::vector<uint8_t> *dup = nullptr;
@@ -394,15 +390,17 @@ void MariaDBTxn::report_deferred_dup_key(THD *thd) {
     }
     if (present) { dup = &op.key; break; }
   }
-  if (deferred_reporter_ && dup) {
-    deferred_reporter_(*dup);
+  if (deferred_reporter_ && dup && deferred_reporter_(*dup)) {
     return;
   }
-  // No handler (or no identifiable key): same error code and format the
-  // server uses, without a rendered value. ER_DUP_ENTRY's own format takes
-  // a key *index* as its second argument; the server pairs the ER_DUP_ENTRY
-  // code with the WITH_KEY_NAME format for named keys, and so do we.
-  my_printf_error(ER_DUP_ENTRY, ER_THD_OR_DEFAULT(thd, ER_DUP_ENTRY_WITH_KEY_NAME),
+  // No handler (or no identifiable key): same error code the server uses,
+  // with the WITH_KEY_NAME wording and no rendered value. The format is a
+  // literal on purpose: the server's message table is reached through THD
+  // members, and this plugin's view of THD (sql_class.h without WITH_WSREP)
+  // does not match the server's layout, so only exported functions may take
+  // a THD. ER_DUP_ENTRY's own format takes a key *index*, so it cannot be
+  // paired with a key name.
+  my_printf_error(ER_DUP_ENTRY, "Duplicate entry '%-.192s' for key '%-.192s'",
                   MYF(0), "", "PRIMARY");
 }
 

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -198,7 +198,13 @@ public:
   // the rest of the statement: commit runs before the statement's tables
   // are unlocked, and the handler deregisters itself on unlock/close in
   // case that order is ever different. Cleared by reset().
-  using DupKeyReporter = std::function<void(const std::vector<uint8_t> &pk)>;
+  // Returns true if it reported the error; false to fall back to the
+  // generic report (the key belongs to a table the reporter does not own).
+  using DupKeyReporter = std::function<bool(const std::vector<uint8_t> &pk)>;
+  bool in_deferred_insert() const { return deferred_insert_; }
+  // True once this statement/transaction holds a snapshot or buffered
+  // writes. Deferred-INSERT mode may only begin before either exists.
+  bool has_state() const { return snap_.has_value() || !ops_.empty(); }
   void begin_deferred_insert(const ha_bytecaskdb *handler,
                              DupKeyReporter reporter) {
     deferred_insert_ = true;
@@ -364,7 +370,7 @@ private:
   // finds the first guarded key that now exists, and raises ER_DUP_ENTRY
   // through the registered handler (with the key value) or, without one,
   // with an empty value.
-  void report_deferred_dup_key(THD *thd);
+  void report_deferred_dup_key();
 
   // Bulk-copy mode state (see begin_bulk_copy). Isolated from ops_/lookup_.
   bool bulk_copy_mode_{false};

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -57,8 +57,10 @@ public:
   //
   // The snapshot iterator is one of bytecask::EntryIterator (forward) or
   // bytecask::ReverseEntryIterator (reverse). Stored as optionals; at most
-  // one is engaged. The buffer side is always walked forward (matching the
-  // pre-migration C-API behavior).
+  // one is engaged. The buffer side walks in the same direction as the
+  // snapshot side, and on each step the smaller (forward) or larger
+  // (reverse) key is emitted; on a tie the buffer wins and a tombstone
+  // suppresses the snapshot key.
   // -------------------------------------------------------------------
 
   class MergeIterator {
@@ -77,9 +79,11 @@ public:
                   std::vector<uint8_t> hi,
                   uint32_t table_id, uint16_t index_id);
 
-    // Reverse construction (full table).
+    // Reverse construction (full table). buf_it is the largest buffered key
+    // <= hi, or buf_end when there is none.
     MergeIterator(std::optional<bytecask::ReverseEntryIterator> snap_it,
                   LookupMap::const_iterator buf_it,
+                  LookupMap::const_iterator buf_begin,
                   LookupMap::const_iterator buf_end,
                   std::vector<uint8_t> lo,
                   uint32_t table_id);
@@ -87,6 +91,7 @@ public:
     // Reverse construction (secondary index — key-only snapshot).
     MergeIterator(std::optional<bytecask::ReverseKeyIterator> snap_it,
                   LookupMap::const_iterator buf_it,
+                  LookupMap::const_iterator buf_begin,
                   LookupMap::const_iterator buf_end,
                   std::vector<uint8_t> lo,
                   uint32_t table_id, uint16_t index_id);
@@ -120,6 +125,12 @@ public:
     void load_snap_current();
     bool snap_at_end() const;
     void snap_step();
+    void buf_step();
+    // True when the buffer cursor holds a candidate inside this scan's
+    // table/index namespace and, for forward scans, below the hi bound.
+    bool buf_candidate_valid() const;
+    void emit_buf();
+    void emit_snap();
 
     // At most one of these is engaged.
     std::optional<bytecask::EntryIterator>        snap_fwd_;
@@ -128,7 +139,11 @@ public:
     std::optional<bytecask::ReverseKeyIterator>   snap_key_rev_;
     bool reverse_{false};
 
+    // Buffer cursor. Forward: buf_it_ walks [buf_it_, buf_end_). Reverse:
+    // buf_it_ is the current candidate and steps toward buf_begin_;
+    // buf_end_ marks exhaustion in both directions.
     LookupMap::const_iterator buf_it_;
+    LookupMap::const_iterator buf_begin_;
     LookupMap::const_iterator buf_end_;
     std::vector<uint8_t> bound_;            // forward: hi (exclusive); reverse: lo (informational only)
     uint32_t table_id_;
@@ -279,6 +294,8 @@ public:
 
 private:
   void ensure_snapshot();
+  LookupMap::const_iterator
+  reverse_buffer_start(const std::vector<uint8_t> &hi) const;
   void reset();
   void revert_row_count_deltas();
   void bulk_reset();

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -283,6 +283,19 @@ private:
   void revert_row_count_deltas();
   void bulk_reset();
 
+  struct RowCountDelta {
+    int64_t delta{0};
+    std::atomic<int64_t> *counter{nullptr};
+  };
+  using RowCountDeltas = std::map<uint32_t, RowCountDelta>;
+
+  // Rewinds the write buffer to its first `mark` ops and rebuilds the RYOW
+  // overlay from what remains. Shared by statement rollback and savepoints.
+  void truncate_ops(std::size_t mark);
+  // Undoes the row-count changes made since `saved` was captured and makes
+  // `saved` the current delta set. Shared by statement rollback and savepoints.
+  void restore_row_count_deltas(const RowCountDeltas &saved);
+
   bytecask::DB *db_;
   std::optional<bytecask::Snapshot> snap_;
 
@@ -292,14 +305,16 @@ private:
   // RYOW overlay — fast lookups by key.  nullopt = tombstone.
   LookupMap lookup_;
 
-  struct RowCountDelta {
-    int64_t delta{0};
-    std::atomic<int64_t> *counter{nullptr};
-  };
-
   // Per-table row count deltas accumulated during this transaction.
   // Reverted on rollback or commit failure.
-  std::map<uint32_t, RowCountDelta> row_count_deltas_;
+  RowCountDeltas row_count_deltas_;
+
+  // Where the current statement began, captured when the statement is
+  // registered in begin_if_needed. A statement-level rollback inside a
+  // multi-statement transaction rewinds to here and leaves earlier
+  // statements' work in the buffer.
+  std::size_t stmt_ops_mark_{0};
+  RowCountDeltas stmt_row_count_deltas_;
 
   bool registered_stmt_{false};
   bool registered_all_{false};

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstring>
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -34,6 +35,8 @@ struct THD;
 struct handlerton;
 
 namespace bytecaskdb {
+
+class ha_bytecaskdb;
 
 class MariaDBTxn {
 public:
@@ -189,9 +192,25 @@ public:
   // Enter deferred-dup-check mode for a plain autocommit INSERT: no snapshot
   // is acquired, and commit() builds a snapshot-less WritePlan whose
   // ensure_absent guards (see Op::guard_absent) carry the PK dup check.
-  // A commit conflict on such a plan is reported as HA_ERR_FOUND_DUPP_KEY.
-  // Cleared by reset() at commit/rollback.
-  void begin_deferred_insert() { deferred_insert_ = true; }
+  // A commit conflict on such a plan is reported as HA_ERR_FOUND_DUPP_KEY,
+  // with the duplicate's key value rendered by `handler`, which owns the
+  // TABLE the server's formatter needs. The handler stays registered for
+  // the rest of the statement: commit runs before the statement's tables
+  // are unlocked, and the handler deregisters itself on unlock/close in
+  // case that order is ever different. Cleared by reset().
+  using DupKeyReporter = std::function<void(const std::vector<uint8_t> &pk)>;
+  void begin_deferred_insert(const ha_bytecaskdb *handler,
+                             DupKeyReporter reporter) {
+    deferred_insert_ = true;
+    deferred_handler_ = handler;
+    deferred_reporter_ = std::move(reporter);
+  }
+  void forget_deferred_handler(const ha_bytecaskdb *handler) {
+    if (deferred_handler_ == handler) {
+      deferred_handler_ = nullptr;
+      deferred_reporter_ = nullptr;
+    }
+  }
 
   // In-memory presence probe against the write buffer only (no snapshot, no
   // DB access). Used by the deferred INSERT path to catch duplicates within
@@ -338,6 +357,14 @@ private:
 
   // Set by begin_deferred_insert(); see that method. Reset by reset().
   bool deferred_insert_{false};
+  const ha_bytecaskdb *deferred_handler_{nullptr};  // identity only
+  DupKeyReporter deferred_reporter_;
+
+  // Reports a deferred-INSERT commit conflict as a duplicate primary key:
+  // finds the first guarded key that now exists, and raises ER_DUP_ENTRY
+  // through the registered handler (with the key value) or, without one,
+  // with an empty value.
+  void report_deferred_dup_key(THD *thd);
 
   // Bulk-copy mode state (see begin_bulk_copy). Isolated from ops_/lookup_.
   bool bulk_copy_mode_{false};

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -278,6 +278,7 @@ public:
   bool bulk_unique_prefix_exists(const uint8_t *prefix, std::size_t plen);
 
 private:
+  void ensure_snapshot();
   void reset();
   void revert_row_count_deltas();
   void bulk_reset();

--- a/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
+++ b/bytecaskdb-mariadb-plugin/bytecaskdb_txn.h
@@ -358,6 +358,12 @@ private:
   std::size_t stmt_ops_mark_{0};
   RowCountDeltas stmt_row_count_deltas_;
 
+  struct Savepoint {
+    std::size_t ops_mark;
+    RowCountDeltas row_count_deltas;
+  };
+  std::vector<Savepoint> savepoints_;
+
   bool registered_stmt_{false};
   bool registered_all_{false};
 

--- a/bytecaskdb-mariadb-plugin/docs/mariadb_plugin_guide.md
+++ b/bytecaskdb-mariadb-plugin/docs/mariadb_plugin_guide.md
@@ -147,17 +147,31 @@ MariaDB calls `external_lock(F_WRLCK)` when a statement begins and
 `MariaDBTxn` sits in the per-THD slot (`thd_get_ha_data` / `thd_set_ha_data`)
 and handles all of this:
 
-- **Snapshot** — captured once at `begin_if_needed()`, held for the life of
-  the statement (READ COMMITTED) or the transaction (REPEATABLE READ).
+- **Snapshot** — taken at the first read or write of the statement (or at
+  `begin_if_needed()` for an explicit transaction) and held to its end.
+  Reads and the commit-time conflict check use the same snapshot, so an
+  autocommit read-modify-write cannot overwrite a concurrent commit.
+  The exception is the deferred-INSERT path (`begin_deferred_insert`):
+  a plain autocommit INSERT on a table whose only unique constraint is
+  the PK takes no snapshot and carries an `ensure_absent` guard per row
+  instead.
 - **Write buffer** — `write_row`, `update_row`, `delete_row` all call
   `buffer_put` / `buffer_del` rather than writing directly to the DB.
 - **Read-your-own-writes** — `get()` checks the buffer first, then the
   snapshot. `MergeIterator` merge-walks buffer + snapshot so scans also
   see buffered writes.
 - **Commit** — builds a `WritePlan` from the buffer in insertion order and
-  calls `db->apply_batch()`. If that returns `false` (W-W conflict), commit
-  returns `HA_ERR_LOCK_DEADLOCK` and MariaDB retries the statement.
-- **Rollback** — discards the buffer; snapshot released.
+  calls `db->apply_batch()`. If that returns `nullopt` (W-W conflict),
+  commit returns `HA_ERR_LOCK_DEADLOCK`; the client sees error 1213 and
+  must redo the transaction. The server does not retry.
+- **Rollback** — a session rollback discards the buffer and releases the
+  snapshot. A statement rollback inside a transaction (a failed statement
+  after `BEGIN`) rewinds only that statement: the op log is truncated to
+  the mark recorded when the statement was registered, and the row
+  counters are restored to the checkpoint taken at the same time.
+- **Savepoints** — each `SAVEPOINT` records the op-log mark and a
+  row-counter checkpoint on a stack in `MariaDBTxn`; the server's
+  savepoint slot holds the stack index. `ROLLBACK TO` restores both.
 
 The dual-structure buffer (`ops_` ordered log + `lookup_` sorted map) is
 the core of `bytecaskdb_txn.h`. `ops_` preserves causality for commit;
@@ -280,14 +294,18 @@ handler can call them from `create()`, `delete_table()`, `rename_table()`.
 
 ## Row format
 
-Rows are stored as a 3-byte envelope followed by the raw MariaDB record
-buffer (`table->s->reclength` bytes), optionally followed by BLOB data:
+Rows are stored as a 3-byte envelope followed by the fields in table
+order, optionally followed by BLOB data:
 
 ```
-byte 0:     format version (currently 0x01)
+byte 0:     format version (currently 0x02)
 byte 1-2:   schema_version LE u16  (bumped on ALTER TABLE)
-byte 3..N:  raw MariaDB record buffer (reclength bytes)
-byte N+1..: concatenated BLOB field data (if any)
+byte 3..:   null bitmap, then each field:
+              multi-byte-charset CHAR:  [actual_len LE u16][data] (trailing
+                                        spaces stripped)
+              everything else:          pack_length() bytes as in record[0]
+              BLOB:                     the length/pointer slot; data follows
+then:       concatenated BLOB field data (if any)
 ```
 
 The schema version lets the decoder apply defaults for added columns or skip
@@ -400,11 +418,15 @@ features) is the remaining gap before production use.
   is taken once in `begin_if_needed()`. All reads in that statement see the
   same consistent state.
 
-- **`apply_batch` returning false is not a fatal error.** It means W-W
+- **`apply_batch` returning `nullopt` is not a fatal error.** It means W-W
   conflict: two transactions modified the same key concurrently. The commit
   path maps it to `HA_ERR_LOCK_DEADLOCK`. The application must re-read the
   affected data and rebuild the transaction from scratch — a plain retry of
   the same writes will conflict again.
+
+- **No pointer into the catalog cache escapes `s_catalog_mu`.**
+  `catalog_copy_meta` copies `TableMeta` out under the lock; handlers cache
+  the index list at `open()` and DML paths use that copy.
 
 - **The catalog in-memory cache is the source of truth for reads; the DB is
   the source of truth for recovery.** At startup, `catalog_init()` rebuilds

--- a/bytecaskdb-mariadb-plugin/docs/steady_state_plan.md
+++ b/bytecaskdb-mariadb-plugin/docs/steady_state_plan.md
@@ -136,25 +136,40 @@ final average.
 
 No new SQL features until one of these branches is taken.
 
-## 6. Backlog from the review (not blocking)
+## 6. Review findings fixed alongside the blockers
 
-| Item | Note |
+All landed on the same branch as §2 and §3, one commit each.
+
+| Item | Outcome |
 |---|---|
-| Savepoint row-count drift | `savepoint_rollback` truncates `ops_` but not `row_count_deltas_`; `stats.records` drifts after `ROLLBACK TO SAVEPOINT`. |
-| Catalog pointer escapes its mutex | `catalog_lookup_meta` returns a pointer into a locked map; `update_row`, `delete_row`, `check` use it unlocked. The in-place `DROP FOREIGN KEY` ALTER reassigns the entry under `HA_ALTER_INPLACE_NO_LOCK`. Extend the BC-241 handler-side cache (`indexes_`) to those paths. |
-| Deferred-INSERT error message | Commit-time duplicate prints `Duplicate entry ''` because `apply_batch` does not say which guard failed. |
-| Triggers on deferred INSERT | A trigger that writes another table in a deferred autocommit INSERT gets no snapshot. Add a trigger functional test or exclude `table->triggers` from the deferred path. |
-| `records_in_range` | Returns a constant tenth of the table; the optimizer cannot rank ranges. |
-| Plugin guide | Says the server retries on deadlock; it does not. |
+| Savepoint row-count drift | Savepoints now checkpoint the row counters; `ROLLBACK TO` restores them. |
+| Catalog pointer escapes its mutex | `catalog_lookup_meta` replaced by `catalog_copy_meta` (copy under lock); DML paths use the handler's cached index list. |
+| Deferred-INSERT error message | Reported through the server's `print_keydup_error` with the key value, code 1062. PR #29 had changed the code to 1586, which broke every client that checks 1062. |
+| Triggers on deferred INSERT | Tables with triggers take the eager path; deferred mode can only start on a transaction with no snapshot and no buffered writes. The mixed state crashed the server (THD layout mismatch in the fallback message path). |
+| `records_in_range` | Exact count up to 1024 keys, merged with buffered writes; fallback fraction above that. |
+| Plugin guide | Snapshot timing, no server retry on 1213, V2 row format, statement rollback and savepoint semantics corrected. |
+
+Found while fixing §2.3 and fixed in the engine: `riter_from(from)` started
+one key too high when `from` was a strict prefix of an existing key. For the
+plugin that meant a descending PK scan on a table whose neighbouring table
+id had rows lost its whole snapshot side. Engine test added; the plugin
+functional suite has a neighbour-table case.
+
+Still open, not blocking: the composite-key `HA_READ_PREFIX_LAST` path had
+never worked (it was only reachable through the now-fixed
+`index_read_map`), so any optimizer plan that relied on it before this
+branch was returning wrong results silently. Worth a note in the release
+notes when this ships.
 
 ## 7. Status
 
 | Step | Status |
 |---|---|
-| PR #28 closed, branch kept | pending |
+| PR #28 closed, branch kept | pending (user action) |
 | PR #29 merged | done (d8f5f1f) |
-| 2.1 autocommit snapshot | open |
-| 2.2 statement rollback | open |
-| 2.3 reverse merge scan | open |
-| 3 semantics / FK flag / README | open |
-| 4 steady-state run | blocked on 2.x |
+| 2.1 autocommit snapshot | done |
+| 2.2 statement rollback | done |
+| 2.3 reverse merge scan + find flags | done, plus engine `riter_from` fix |
+| 3 semantics / FK flag / README | done; `run-sysbench.sh` comment corrected in the working tree alongside the uncommitted harness changes |
+| 6 review findings | done |
+| 4 steady-state run | ready to run |

--- a/bytecaskdb-mariadb-plugin/docs/steady_state_plan.md
+++ b/bytecaskdb-mariadb-plugin/docs/steady_state_plan.md
@@ -1,0 +1,160 @@
+# MariaDB plugin — steady-state validation plan
+
+Date: 2026-09-12. Status: **active**. Supersedes feature work until the
+decision in [§5](#5-decision-after-the-run) is taken.
+
+## 1. Decision
+
+Park new SQL features. Fix three correctness gaps found in review, then run a
+long, larger-than-buffer-pool comparison against InnoDB and let that data pick
+the next engine task.
+
+The 60-second sysbench runs in `benchmarks/sysbench_results.csv` (500k rows,
+2 vCPU codespace, InnoDB at `innodb_flush_log_at_trx_commit=1`) do not support
+"close to InnoDB" once more than one client thread is involved:
+
+| Workload | 1 thread | 2 threads | 4 threads |
+|---|---|---|---|
+| oltp_point_select | +3% | +16% | +13% |
+| oltp_read_only | -11% | -8% | -12% |
+| oltp_write_only | -7% | -38% | -42% |
+| oltp_insert | -36% | -47% | -48% |
+| oltp_read_write | +24% | -38% | -50% |
+
+Two signals in that table matter more than the percentages. Write throughput
+*drops* from one thread to two, which points at group commit never batching at
+low concurrency. And a 60-second run on a table that fits in RAM cannot show
+the failure modes either engine is expected to have over hours: InnoDB
+checkpoint and purge stalls, ByteCaskDB vacuum interference and memory growth.
+
+PR #28 (deferred `EngineState` reclamation) is closed, branch kept. Its own
+benchmark gate was never met and BC-245 removed most of its premise. Reopen
+only if a fresh `oltp_insert` profile on current main still shows
+`Node::release` above ~10% of the client thread.
+
+## 2. Blockers — fix before the long run
+
+Each is small, plugin-local, and lands with a functional test. Without them the
+long run measures bugs.
+
+### 2.1 Autocommit reads run before the OCC snapshot exists
+
+`MariaDBTxn::begin_if_needed` only takes the snapshot for explicit
+transactions. In autocommit, `MariaDBTxn::get` and `MariaDBTxn::exists` fall
+through to the live DB and the snapshot is taken later by the first buffered
+write. Two clients running `UPDATE t SET v = v + 1 WHERE id = 1` can both read
+v, one commits, the other snapshots *after* that commit, and its write passes
+the engine's write-write check. One increment is lost. The same ordering
+applies to `update_row`'s PK-change duplicate probe and to INSERTs on tables
+with a UNIQUE secondary index (PR #29 covers only plain INSERTs on
+PK-only-unique tables).
+
+Fix: take the snapshot in `get` and `exists` when none is held, as
+`iter_prefix` already does. The engine treats "key appeared since snapshot" as
+a conflict, so the late writer then gets error 1213 instead of silently
+overwriting.
+
+Test: `tests/functional/test_concurrency.py`, two connections in autocommit
+racing the increment above; assert the final value is 2 or one connection got
+1213.
+
+### 2.2 Statement rollback inside a transaction discards the whole buffer
+
+`MariaDBTxn::rollback(all=false)` clears `ops_` and `lookup_` entirely. If the
+third statement of a `BEGIN` block fails, statements one and two vanish and
+the later `COMMIT` returns success as a no-op.
+
+Fix: record `ops_.size()` at statement start (the `!registered_stmt_` branch
+of `begin_if_needed`) and truncate to it on statement rollback, reusing the
+rebuild in `savepoint_rollback`. Revert only that statement's row-count
+deltas.
+
+Test: `cases/transactions.yaml` — BEGIN, two inserts, a third that hits a
+duplicate key, COMMIT; assert the first two rows exist.
+
+### 2.3 Reverse scans with buffered writes
+
+`MergeIterator` walks the write buffer forward in reverse mode and its compare
+assumes ascending order, so `BEGIN; INSERT ...; SELECT ... ORDER BY id DESC`
+returns uncommitted rows out of order. Separately, `index_read_map` sends
+`HA_READ_BEFORE_KEY` and `HA_READ_KEY_OR_PREV` down the forward-iterator
+path, which is what the optimizer issues for descending range scans.
+
+Fix: walk the buffer with a reverse iterator when `reverse_` is set and invert
+the compare; route the two find flags to `riter_prefix` /
+`riter_index_prefix`.
+
+Test: `cases/index_scan_completeness.yaml` — inside a transaction with
+uncommitted rows, `WHERE id < 10 ORDER BY id DESC` on PK and on a secondary
+index.
+
+## 3. Semantics to state plainly
+
+Half a day, no engine change.
+
+- Drop `HTON_SUPPORTS_FOREIGN_KEYS` from `bytecaskdb_init`. FK metadata is
+  kept for DDL only; nothing is enforced.
+- Add a "Differences from InnoDB" section to the plugin README:
+  `SELECT ... FOR UPDATE` is a plain snapshot read (no `ensure_unchanged`
+  guards are emitted); write-write conflicts surface at COMMIT as error 1213
+  and are not retried by the server; whole transactions are buffered in RAM
+  until commit; long-lived snapshots (`mysqldump --single-transaction`)
+  defer vacuum.
+- Fix the `run-sysbench.sh` comment that says the secondary index is off by
+  default while the flag turns it on.
+
+## 4. Steady-state benchmark protocol
+
+Machine: at least 4 physical cores, local SSD, nothing else running. The
+2 vCPU codespace is not usable for the concurrency rows.
+
+| Parameter | Value |
+|---|---|
+| Table | 1 table, 5M rows (~1 GB) |
+| InnoDB buffer pool | 1G, so the working set does not fit |
+| Durability | `innodb_flush_log_at_trx_commit=1`; ByteCaskDB `sync=true` (default) |
+| Workloads | `oltp_write_only`, `oltp_read_write`, secondary index on |
+| Threads | 8 |
+| Duration | 45 minutes per workload per engine |
+| Sampling | `--report-interval=10`; keep p95, p99 and max per interval |
+| Engine counters | `SHOW ENGINE BYTECASKDB STATUS` every 60 s: vacuum bytes reclaimed, fsyncs, open files; RSS of `mariadbd` |
+| InnoDB counters | `Innodb_buffer_pool_wait_free`, `Innodb_log_waits`, `Innodb_history_list_length` every 60 s |
+
+Report per engine: tps over time, p99 over time, max latency per interval,
+RSS over time. The interesting result is the shape of the curves, not the
+final average.
+
+## 5. Decision after the run
+
+- ByteCaskDB flat while InnoDB degrades: the design claim holds. Next task is
+  the low-concurrency group-commit fix (2-thread write throughput below
+  1-thread), then re-run.
+- Both flat: the write-path CPU gap is the priority. Continue BC-246/BC-247
+  (radix-tree clone cost) and re-profile `oltp_insert` on current main.
+- ByteCaskDB degrades: find out why before anything else. Likely suspects are
+  vacuum contending with the writer and in-memory transaction buffering.
+
+No new SQL features until one of these branches is taken.
+
+## 6. Backlog from the review (not blocking)
+
+| Item | Note |
+|---|---|
+| Savepoint row-count drift | `savepoint_rollback` truncates `ops_` but not `row_count_deltas_`; `stats.records` drifts after `ROLLBACK TO SAVEPOINT`. |
+| Catalog pointer escapes its mutex | `catalog_lookup_meta` returns a pointer into a locked map; `update_row`, `delete_row`, `check` use it unlocked. The in-place `DROP FOREIGN KEY` ALTER reassigns the entry under `HA_ALTER_INPLACE_NO_LOCK`. Extend the BC-241 handler-side cache (`indexes_`) to those paths. |
+| Deferred-INSERT error message | Commit-time duplicate prints `Duplicate entry ''` because `apply_batch` does not say which guard failed. |
+| Triggers on deferred INSERT | A trigger that writes another table in a deferred autocommit INSERT gets no snapshot. Add a trigger functional test or exclude `table->triggers` from the deferred path. |
+| `records_in_range` | Returns a constant tenth of the table; the optimizer cannot rank ranges. |
+| Plugin guide | Says the server retries on deadlock; it does not. |
+
+## 7. Status
+
+| Step | Status |
+|---|---|
+| PR #28 closed, branch kept | pending |
+| PR #29 merged | done (d8f5f1f) |
+| 2.1 autocommit snapshot | open |
+| 2.2 statement rollback | open |
+| 2.3 reverse merge scan | open |
+| 3 semantics / FK flag / README | open |
+| 4 steady-state run | blocked on 2.x |

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -95,6 +95,7 @@ int ha_bytecaskdb::external_lock(THD *thd, int lock_type) {
     txn->begin_if_needed(thd, bytecaskdb_hton);
     txn_cached_ = txn;
   } else {
+    if (txn_cached_) { txn_cached_->forget_deferred_handler(this); }
     txn_cached_ = nullptr;
   }
   return 0;
@@ -354,6 +355,7 @@ void ha_bytecaskdb::seed_cached_autoinc(uint64_t high_water) const {
 // ---------------------------------------------------------------------------
 
 int ha_bytecaskdb::close() {
+  if (txn_cached_) { txn_cached_->forget_deferred_handler(this); }
   merge_scan_.reset();
   merge_index_.reset();
   indexes_.clear();
@@ -554,7 +556,10 @@ int ha_bytecaskdb::write_row(const uchar *buf) {
       return HA_ERR_FOUND_DUPP_KEY;
     }
   }
-  if (defer_dup) { txn->begin_deferred_insert(); }
+  if (defer_dup) {
+    txn->begin_deferred_insert(
+        this, [this](const std::vector<uint8_t> &pk) { report_dup_pk(pk); });
+  }
 
   // Check unique secondary index constraints.
   if (!indexes_.empty()) {
@@ -703,6 +708,26 @@ int ha_bytecaskdb::bulk_copy_write_row(const uchar *buf) {
     if (e) { return e; }
   }
   return 0;
+}
+
+// ---------------------------------------------------------------------------
+// report_dup_pk() — deferred-INSERT duplicate, reported at commit time.
+//
+// The statement has already failed, so record[0] is free to receive the
+// duplicate's key columns; print_keydup_error renders them exactly as the
+// eager write_row path would have (code ER_DUP_ENTRY, "Duplicate entry
+// '...' for key 'PRIMARY'").
+// ---------------------------------------------------------------------------
+
+void ha_bytecaskdb::report_dup_pk(const std::vector<uint8_t> &pk) {
+  const uint pk_idx = table->s->primary_key;
+  errkey = saved_errkey_ = pk_idx;
+#ifndef PLUGIN_TESTING
+  decode_pk(table, pk.data(), pk.size(), table->record[0], decode_pk_scratch_);
+  print_keydup_error(table, &table->key_info[pk_idx], MYF(0));
+#else
+  my_error(ER_DUP_ENTRY, MYF(0), "", "PRIMARY");
+#endif
 }
 
 // ---------------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -490,15 +490,18 @@ bool ha_bytecaskdb::has_unique_secondary_index() const {
 }
 
 // True when the current statement is a plain autocommit INSERT (no BEGIN, no
-// autocommit=0, not INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE). Such
-// a statement can defer its PK duplicate check to commit via an ensure_absent
-// guard instead of an eager per-row DB probe + snapshot.
+// autocommit=0, not INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE) into a
+// table without triggers. Such a statement can defer its PK duplicate check
+// to commit via an ensure_absent guard instead of an eager per-row DB probe +
+// snapshot. A trigger may read or write other tables in the same statement,
+// and those accesses need the snapshot the deferred path skips.
 bool ha_bytecaskdb::stmt_allows_deferred_dupcheck() const {
 #ifdef PLUGIN_TESTING
   return false;
 #else
   return thd_sql_command(ha_thd()) == SQLCOM_INSERT &&
-         !thd_test_options(ha_thd(), OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+         !thd_test_options(ha_thd(), OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN) &&
+         table->triggers == nullptr;
 #endif
 }
 
@@ -540,9 +543,16 @@ int ha_bytecaskdb::write_row(const uchar *buf) {
   // INSERT IGNORE / REPLACE / ON DUPLICATE KEY UPDATE need the per-row verdict
   // (dupcheck_eager_), and a UNIQUE secondary index needs the eager snapshot
   // path, so both fall through to the classic check.
+  // Deferred mode may only begin on a transaction with no snapshot and no
+  // buffered writes: the first row of the statement. Once it is on, every
+  // further PK insert in the statement stays on it and carries its own
+  // commit-time guard, since an eager probe would read the live DB with no
+  // write-write protection behind it.
   const bool defer_dup =
-      !no_pk && !dupcheck_eager_ && !has_unique_secondary_index() &&
-      stmt_allows_deferred_dupcheck();
+      !no_pk && (txn->in_deferred_insert() ||
+                 (!txn->has_state() && !dupcheck_eager_ &&
+                  !has_unique_secondary_index() &&
+                  stmt_allows_deferred_dupcheck()));
 
   // PK-less rows can't collide on the primary key (synthetic rowids are
   // monotonic), so skip the dup check there. For PK tables, eager dup check
@@ -556,9 +566,9 @@ int ha_bytecaskdb::write_row(const uchar *buf) {
       return HA_ERR_FOUND_DUPP_KEY;
     }
   }
-  if (defer_dup) {
+  if (defer_dup && !txn->in_deferred_insert()) {
     txn->begin_deferred_insert(
-        this, [this](const std::vector<uint8_t> &pk) { report_dup_pk(pk); });
+        this, [this](const std::vector<uint8_t> &pk) { return report_dup_pk(pk); });
   }
 
   // Check unique secondary index constraints.
@@ -719,7 +729,10 @@ int ha_bytecaskdb::bulk_copy_write_row(const uchar *buf) {
 // '...' for key 'PRIMARY'").
 // ---------------------------------------------------------------------------
 
-void ha_bytecaskdb::report_dup_pk(const std::vector<uint8_t> &pk) {
+bool ha_bytecaskdb::report_dup_pk(const std::vector<uint8_t> &pk) {
+  if (!key_belongs_to_table(pk.data(), pk.size(), table_id_)) {
+    return false;  // another table's key: let the caller report generically
+  }
   const uint pk_idx = table->s->primary_key;
   errkey = saved_errkey_ = pk_idx;
 #ifndef PLUGIN_TESTING
@@ -728,6 +741,7 @@ void ha_bytecaskdb::report_dup_pk(const std::vector<uint8_t> &pk) {
 #else
   my_error(ER_DUP_ENTRY, MYF(0), "", "PRIMARY");
 #endif
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -1021,8 +1021,94 @@ int ha_bytecaskdb::extra(enum ha_extra_function operation) {
 }
 
 // ---------------------------------------------------------------------------
-// index_read_map() — PK point lookup + range scan start
+// index_read_map() — positions a scan on the PK or a secondary index.
+//
+// MariaDB describes the start position with a (possibly partial) key and a
+// find_flag. Every flag maps onto the same four choices: which direction to
+// walk, whether the unspecified key bytes are padded low (before every key
+// with the given prefix) or high (after every such key), whether keys that
+// still carry the prefix must be skipped (AFTER/BEFORE), and whether the
+// first key must carry the prefix (EXACT/PREFIX/PREFIX_LAST).
 // ---------------------------------------------------------------------------
+
+namespace {
+
+struct SeekMode {
+  bool reverse{false};
+  bool pad_high{false};
+  bool skip_prefix{false};
+  bool require_prefix{false};
+};
+
+SeekMode seek_mode_for(enum ha_rkey_function f) {
+  switch (f) {
+    case HA_READ_KEY_EXACT:           return {false, false, false, true};
+    case HA_READ_PREFIX:              return {false, false, false, true};
+    case HA_READ_KEY_OR_NEXT:         return {false, false, false, false};
+    case HA_READ_AFTER_KEY:           return {false, true,  true,  false};
+    case HA_READ_KEY_OR_PREV:         return {true,  true,  false, false};
+    case HA_READ_PREFIX_LAST_OR_PREV: return {true,  true,  false, false};
+    case HA_READ_PREFIX_LAST:         return {true,  true,  false, true};
+    case HA_READ_BEFORE_KEY:          return {true,  false, true,  false};
+    default:                          return {};  // spatial MBR flags: unsupported
+  }
+}
+
+bool key_has_prefix(const MariaDBTxn::MergeIterator &it,
+                    const std::vector<uint8_t> &prefix) {
+  return it.key_len() >= prefix.size() &&
+         std::memcmp(it.key_data(), prefix.data(), prefix.size()) == 0;
+}
+
+}  // namespace
+
+// Fills search_key_buf_ with the encoded search key for the active index:
+// namespace + ids, the `prefix_len` bytes of the optimizer's key put through
+// the same VARCHAR fix-up and mem-comparable transform as stored keys, and
+// then the unsupplied remainder padded in *transformed* space — 0x00 sorts
+// before every stored key sharing the prefix, 0xFF after every one. (Padding
+// before the transform would be wrong: 0xFF bytes through the signed-integer
+// transform encode -1, not the maximum.) For a secondary index padded high
+// the PK suffix is padded with 0xFF as well.
+// Returns the length of namespace + transformed prefix, i.e. the bytes a
+// stored key must share to "have the prefix".
+std::size_t ha_bytecaskdb::build_search_key(const uchar *key, uint prefix_len,
+                                            bool pad_high) {
+  const bool on_pk = (active_index == table->s->primary_key);
+  const KEY &key_info = table->key_info[active_index];
+  const uint key_len = key_info.key_length;
+  const std::size_t ns_len = on_pk ? 5 : 7;
+
+  search_key_buf_.assign(ns_len + key_len, 0);
+  uint8_t *p = search_key_buf_.data();
+  p[0] = on_pk ? kNsRow : kNsIndex;
+  write_table_id_prefix(p + 1, table_id_);
+  if (!on_pk) {
+    p[5] = static_cast<uint8_t>((active_index >> 8) & 0xFF);
+    p[6] = static_cast<uint8_t>( active_index       & 0xFF);
+  }
+
+  uint8_t *kp = p + ns_len;
+  std::memcpy(kp, key, prefix_len);
+
+  // The fix-ups walk every key part; the zero-filled unsupplied parts read
+  // as empty and are left as zeros. The transform is limited to the
+  // supplied prefix (whole parts), so only those bytes are rewritten.
+  if (on_pk) {
+    normalize_padspace_pk(kp, &key_info);
+  } else {
+    fix_varchar_key_encoding(kp, table, active_index);
+  }
+  make_mem_comparable(kp, &key_info, prefix_len);
+
+  if (pad_high) {
+    std::memset(kp + prefix_len, 0xFF, key_len - prefix_len);
+    if (!on_pk) {
+      search_key_buf_.resize(ns_len + key_len + pk_suffix_length(table), 0xFF);
+    }
+  }
+  return ns_len + prefix_len;
+}
 
 int ha_bytecaskdb::index_read_map(uchar *buf, const uchar *key,
                                    key_part_map keypart_map,
@@ -1032,154 +1118,75 @@ int ha_bytecaskdb::index_read_map(uchar *buf, const uchar *key,
   auto *txn = txn_cached_;
   if (!txn) { return HA_ERR_GENERIC; }
 
-  if (active_index == table->s->primary_key) {
-    // Primary key operations: direct row access [0x02 | table_id | pk]
-    uint pk_idx = table->s->primary_key;
-    const KEY &pk_info = table->key_info[pk_idx];
-    uint pk_len = pk_info.key_length;
+  const bool on_pk = (active_index == table->s->primary_key);
+  const KEY &key_info = table->key_info[active_index];
+  const uint key_len = key_info.key_length;
 
-    // Compute how many bytes of the search key are actually provided.
-    uint actual_prefix_len = 0;
-    for (uint i = 0; i < pk_info.user_defined_key_parts; ++i) {
-      if (!(keypart_map & (key_part_map(1) << i))) break;
-      actual_prefix_len += pk_info.key_part[i].store_length;
-    }
-
-    search_key_buf_.resize(5 + pk_len);
-    search_key_buf_[0] = kNsRow;
-    search_key_buf_[1] = static_cast<uint8_t>((table_id_ >> 24) & 0xFF);
-    search_key_buf_[2] = static_cast<uint8_t>((table_id_ >> 16) & 0xFF);
-    search_key_buf_[3] = static_cast<uint8_t>((table_id_ >>  8) & 0xFF);
-    search_key_buf_[4] = static_cast<uint8_t>( table_id_        & 0xFF);
-    std::memcpy(search_key_buf_.data() + 5, key, actual_prefix_len);
-    if (actual_prefix_len < pk_len) {
-      std::memset(search_key_buf_.data() + 5 + actual_prefix_len, 0,
-                  pk_len - actual_prefix_len);
-    }
-    normalize_padspace_pk(search_key_buf_.data() + 5, &pk_info);
-    make_mem_comparable(search_key_buf_.data() + 5, &pk_info, pk_len);
-
-    if (find_flag == HA_READ_KEY_EXACT) {
-      int found = txn->get(search_key_buf_.data(), search_key_buf_.size(),
-                           row_value_buf_);
-      if (found < 0) { return HA_ERR_GENERIC; }
-      if (found == 0) { return HA_ERR_KEY_NOT_FOUND; }
-
-      key_restore(buf, key, const_cast<KEY *>(&pk_info), pk_len);
-
-      decode_row(table,
-                 reinterpret_cast<const uint8_t *>(row_value_buf_.data()),
-                 row_value_buf_.size(), buf);
-      save_current_row_key(search_key_buf_.data(), search_key_buf_.size());
-      return 0;
-    }
-
-    if (find_flag == HA_READ_PREFIX_LAST ||
-        find_flag == HA_READ_PREFIX_LAST_OR_PREV) {
-      std::vector<uint8_t> hi_key(5 + pk_len);
-      std::memcpy(hi_key.data(), search_key_buf_.data(), 5 + actual_prefix_len);
-      std::memset(hi_key.data() + 5 + actual_prefix_len, 0xFF,
-                  pk_len - actual_prefix_len);
-      make_mem_comparable(hi_key.data() + 5, &pk_info, pk_len);
-
-      auto lo = table_id_prefix(table_id_);
-      merge_index_ = txn->riter_prefix(hi_key.data(), hi_key.size(),
-                                        lo.data(), lo.size(), table_id_);
-      if (!merge_index_) { return HA_ERR_GENERIC; }
-
-      int rc = index_read_current(buf);
-      if (rc != 0) return rc;
-
-      if (current_row_key_.size() < 5 + actual_prefix_len) {
-        return HA_ERR_KEY_NOT_FOUND;
-      }
-      if (std::memcmp(current_row_key_.data() + 5,
-                      search_key_buf_.data() + 5, actual_prefix_len) != 0) {
-        return HA_ERR_KEY_NOT_FOUND;
-      }
-      return 0;
-    }
-
-    // Forward range scan: open merge iterator at search key.
-    auto hi = table_id_upper_bound(table_id_);
-    merge_index_ = txn->iter_prefix(search_key_buf_.data(), search_key_buf_.size(),
-                                     hi.data(), hi.size(), table_id_);
-    if (!merge_index_) { return HA_ERR_GENERIC; }
-
-    return index_read_current(buf);
-
-  } else {
-    // Secondary index operations: access via index namespace [0x03 | table_id | index_id]
-    const KEY &key_info = table->key_info[active_index];
-    uint sec_key_len = key_info.key_length;
-
-    search_key_buf_.resize(7 + sec_key_len);
-    search_key_buf_[0] = kNsIndex;
-    search_key_buf_[1] = static_cast<uint8_t>((table_id_ >> 24) & 0xFF);
-    search_key_buf_[2] = static_cast<uint8_t>((table_id_ >> 16) & 0xFF);
-    search_key_buf_[3] = static_cast<uint8_t>((table_id_ >>  8) & 0xFF);
-    search_key_buf_[4] = static_cast<uint8_t>( table_id_        & 0xFF);
-    search_key_buf_[5] = static_cast<uint8_t>((active_index >> 8) & 0xFF);
-    search_key_buf_[6] = static_cast<uint8_t>( active_index       & 0xFF);
-    // keypart_map tells us which key parts are valid in `key`. Only copy those
-    // bytes; zero-fill the rest so the scan starts at the correct position.
-    uint actual_packed_len = 0;
-    for (uint i = 0; i < key_info.user_defined_key_parts; ++i) {
-      if (!(keypart_map & (key_part_map(1) << i))) break;
-      actual_packed_len += key_info.key_part[i].store_length;
-    }
-    std::memcpy(search_key_buf_.data() + 7, key, actual_packed_len);
-    if (actual_packed_len < sec_key_len) {
-      std::memset(search_key_buf_.data() + 7 + actual_packed_len, 0,
-                  sec_key_len - actual_packed_len);
-    }
-    // The optimizer key buffer is in key_copy() format (includes VARCHAR length
-    // prefix). encode_sec_key() strips that prefix via fix_varchar_key_encoding;
-    // apply the same transformation here so the search key matches stored keys.
-    fix_varchar_key_encoding(search_key_buf_.data() + 7, table, active_index);
-    make_mem_comparable(search_key_buf_.data() + 7, &key_info, sec_key_len);
-
-    // Save the covered-prefix bytes for index_next_same comparison.
-    // Use actual_packed_len (includes null indicators) not just data length.
-    sec_search_key_.assign(search_key_buf_.begin(),
-                           search_key_buf_.begin() + 7 + actual_packed_len);
-
-    auto hi = index_id_upper_bound(table_id_, static_cast<uint16_t>(active_index));
-
-    if (find_flag == HA_READ_AFTER_KEY) {
-      // Position strictly after all entries with this secondary key value.
-      // Append 0xFF bytes to create an upper bound past all PK suffixes.
-      uint suffix_len = pk_suffix_length(table);
-      sec_row_key_buf_.resize(search_key_buf_.size() + suffix_len);
-      std::memcpy(sec_row_key_buf_.data(), search_key_buf_.data(),
-                  search_key_buf_.size());
-      std::memset(sec_row_key_buf_.data() + search_key_buf_.size(), 0xFF,
-                  suffix_len);
-      merge_index_ = txn->iter_index_prefix(sec_row_key_buf_.data(),
-                                            sec_row_key_buf_.size(),
-                                            hi.data(), hi.size(),
-                                            table_id_, static_cast<uint16_t>(active_index));
-    } else {
-      // For HA_READ_KEY_EXACT and other modes, start at the search key position.
-      merge_index_ = txn->iter_index_prefix(search_key_buf_.data(),
-                                            search_key_buf_.size(),
-                                            hi.data(), hi.size(),
-                                            table_id_, static_cast<uint16_t>(active_index));
-    }
-    if (!merge_index_) { return HA_ERR_GENERIC; }
-
-    if (find_flag == HA_READ_KEY_EXACT) {
-      if (!merge_index_->valid()) { return HA_ERR_KEY_NOT_FOUND; }
-      // Verify the found key actually has the search prefix (sans PK suffix).
-      size_t prefix_len = 7 + actual_packed_len;
-      if (merge_index_->key_len() < prefix_len ||
-          std::memcmp(merge_index_->key_data(), search_key_buf_.data(), prefix_len) != 0) {
-        return HA_ERR_KEY_NOT_FOUND;
-      }
-    }
-
-    return index_read_current(buf);
+  // Bytes of `key` that keypart_map marks as supplied (whole leading parts).
+  uint prefix_len = 0;
+  for (uint i = 0; i < key_info.user_defined_key_parts; ++i) {
+    if (!(keypart_map & (key_part_map(1) << i))) break;
+    prefix_len += key_info.key_part[i].store_length;
   }
+
+  const SeekMode mode = seek_mode_for(find_flag);
+  const std::size_t ns_prefix_len =
+      build_search_key(key, prefix_len, mode.pad_high);
+
+  // Transformed prefix, used by index_next_same and the prefix rules below.
+  sec_search_key_.assign(search_key_buf_.begin(),
+                         search_key_buf_.begin() +
+                             static_cast<std::ptrdiff_t>(ns_prefix_len));
+
+  // Full-key exact PK lookup: a point read, no scan.
+  if (on_pk && find_flag == HA_READ_KEY_EXACT && prefix_len == key_len) {
+    merge_index_.reset();
+    int found = txn->get(search_key_buf_.data(), search_key_buf_.size(),
+                         row_value_buf_);
+    if (found < 0) { return HA_ERR_GENERIC; }
+    if (found == 0) { return HA_ERR_KEY_NOT_FOUND; }
+
+    key_restore(buf, key, const_cast<KEY *>(&key_info), key_len);
+    decode_row(table,
+               reinterpret_cast<const uint8_t *>(row_value_buf_.data()),
+               row_value_buf_.size(), buf);
+    save_current_row_key(search_key_buf_.data(), search_key_buf_.size());
+    return 0;
+  }
+
+  const auto idx = static_cast<uint16_t>(active_index);
+  if (mode.reverse) {
+    auto lo = on_pk ? table_id_prefix(table_id_) : index_id_prefix(table_id_, idx);
+    merge_index_ = on_pk
+        ? txn->riter_prefix(search_key_buf_.data(), search_key_buf_.size(),
+                            lo.data(), lo.size(), table_id_)
+        : txn->riter_index_prefix(search_key_buf_.data(), search_key_buf_.size(),
+                                  lo.data(), lo.size(), table_id_, idx);
+  } else {
+    auto hi = on_pk ? table_id_upper_bound(table_id_)
+                    : index_id_upper_bound(table_id_, idx);
+    merge_index_ = on_pk
+        ? txn->iter_prefix(search_key_buf_.data(), search_key_buf_.size(),
+                           hi.data(), hi.size(), table_id_)
+        : txn->iter_index_prefix(search_key_buf_.data(), search_key_buf_.size(),
+                                 hi.data(), hi.size(), table_id_, idx);
+  }
+  if (!merge_index_) { return HA_ERR_GENERIC; }
+
+  if (mode.skip_prefix) {
+    // AFTER_KEY / BEFORE_KEY: the padded bound may still land on a key that
+    // carries the prefix (a column at its extreme value); step past it.
+    while (merge_index_->valid() && key_has_prefix(*merge_index_, sec_search_key_)) {
+      merge_index_->next();
+    }
+  }
+  if (mode.require_prefix) {
+    if (!merge_index_->valid() || !key_has_prefix(*merge_index_, sec_search_key_)) {
+      return HA_ERR_KEY_NOT_FOUND;
+    }
+  }
+
+  return index_read_current(buf);
 }
 
 // ---------------------------------------------------------------------------
@@ -1193,7 +1200,7 @@ int ha_bytecaskdb::index_next(uchar *buf) {
 }
 
 // ---------------------------------------------------------------------------
-// index_next_same() — advance within an equality range on a secondary index.
+// index_next_same() — advance within an equality range.
 //
 // The default handler uses key_cmp_if_same() which compares the field in
 // record[0] against the original packed key.  That comparison breaks for
@@ -1201,34 +1208,21 @@ int ha_bytecaskdb::index_next(uchar *buf) {
 // stored keys, making the stored format diverge from the packed key format
 // that key_cmp_if_same() expects.
 //
-// Instead we compare the binary secondary-key prefix directly: the first
-// sec_search_key_.size() bytes of the stored key must match the saved search
-// key (both already have the VARCHAR length prefix removed).
+// Instead we compare the encoded prefix directly: the stored key must start
+// with the namespace + transformed search prefix that index_read_map saved
+// in sec_search_key_. This works for the PK as well: a full-key PK search
+// never has a "next same" (the next key differs within the prefix), while a
+// partial composite-PK prefix (ref access on the leading columns) does.
 // ---------------------------------------------------------------------------
 
 int ha_bytecaskdb::index_next_same(uchar *buf, const uchar * /*key*/,
                                     uint /*keylen*/) {
   if (!merge_index_ || !merge_index_->valid()) { return HA_ERR_END_OF_FILE; }
-  if (active_index == table->s->primary_key) {
-    // Primary index has unique keys — there is never a "next same".
-    return HA_ERR_END_OF_FILE;
-  }
 
   merge_index_->next();
   if (!merge_index_->valid()) { return HA_ERR_END_OF_FILE; }
 
-  // Safety: verify the key still belongs to our index namespace.
-  if (!key_belongs_to_index(merge_index_->key_data(), merge_index_->key_len(),
-                            table_id_, static_cast<uint16_t>(active_index))) {
-    return HA_ERR_END_OF_FILE;
-  }
-
-  // Verify the stored key still shares the same search-key prefix.
-  if (!sec_search_key_.empty() &&
-      (merge_index_->key_len() < sec_search_key_.size() ||
-       std::memcmp(merge_index_->key_data(),
-                   sec_search_key_.data(),
-                   sec_search_key_.size()) != 0)) {
+  if (!key_has_prefix(*merge_index_, sec_search_key_)) {
     return HA_ERR_END_OF_FILE;
   }
 
@@ -1348,10 +1342,7 @@ int ha_bytecaskdb::index_read_current(uchar *buf) {
       // optimizer later switches keyread off mid-scan.
       sec_row_key_buf_.resize(5 + pk_len);
       sec_row_key_buf_[0] = kNsRow;
-      sec_row_key_buf_[1] = static_cast<uint8_t>((table_id_ >> 24) & 0xFF);
-      sec_row_key_buf_[2] = static_cast<uint8_t>((table_id_ >> 16) & 0xFF);
-      sec_row_key_buf_[3] = static_cast<uint8_t>((table_id_ >>  8) & 0xFF);
-      sec_row_key_buf_[4] = static_cast<uint8_t>( table_id_        & 0xFF);
+      write_table_id_prefix(sec_row_key_buf_.data() + 1, table_id_);
       std::memcpy(sec_row_key_buf_.data() + 5, pk_ptr, pk_len);
       save_current_row_key(sec_row_key_buf_.data(), sec_row_key_buf_.size());
       return 0;
@@ -1360,10 +1351,7 @@ int ha_bytecaskdb::index_read_current(uchar *buf) {
     // 2. Build primary key for row lookup [0x02 | table_id | pk-or-rowid]
     sec_row_key_buf_.resize(5 + pk_len);
     sec_row_key_buf_[0] = kNsRow;
-    sec_row_key_buf_[1] = static_cast<uint8_t>((table_id_ >> 24) & 0xFF);
-    sec_row_key_buf_[2] = static_cast<uint8_t>((table_id_ >> 16) & 0xFF);
-    sec_row_key_buf_[3] = static_cast<uint8_t>((table_id_ >>  8) & 0xFF);
-    sec_row_key_buf_[4] = static_cast<uint8_t>( table_id_        & 0xFF);
+    write_table_id_prefix(sec_row_key_buf_.data() + 1, table_id_);
     std::memcpy(sec_row_key_buf_.data() + 5, pk_ptr, pk_len);
 
     // 3. Fetch full row from primary key namespace
@@ -1452,11 +1440,18 @@ ha_rows ha_bytecaskdb::records_in_range(uint /*index*/, const key_range */*min_k
 }
 
 // ---------------------------------------------------------------------------
-// save_current_row_key() — private helper
+// save_current_row_key() / write_table_id_prefix() — private helpers
 // ---------------------------------------------------------------------------
 
 void ha_bytecaskdb::save_current_row_key(const uint8_t *data, std::size_t len) {
   current_row_key_.assign(data, data + len);
+}
+
+void ha_bytecaskdb::write_table_id_prefix(uint8_t *buf4, uint32_t table_id) {
+  buf4[0] = static_cast<uint8_t>((table_id >> 24) & 0xFF);
+  buf4[1] = static_cast<uint8_t>((table_id >> 16) & 0xFF);
+  buf4[2] = static_cast<uint8_t>((table_id >>  8) & 0xFF);
+  buf4[3] = static_cast<uint8_t>( table_id        & 0xFF);
 }
 
 // ---------------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -223,10 +223,10 @@ int ha_bytecaskdb::open(const char *name, int /*mode*/,
   }
   table_id_ = tid.value();
 
-  const auto *meta = catalog_lookup_meta(table_id_);
-  if (meta) {
-    schema_version_ = static_cast<uint16_t>(meta->schema_version);
-    indexes_ = meta->indexes;
+  TableMeta meta;
+  if (catalog_copy_meta(table_id_, meta)) {
+    schema_version_ = static_cast<uint16_t>(meta.schema_version);
+    indexes_ = std::move(meta.indexes);
   } else {
     indexes_.clear();
   }
@@ -374,8 +374,9 @@ int ha_bytecaskdb::delete_table(const char *name) {
     return 0;  // Nothing to delete.
   }
 
-  // Get table metadata to find secondary indexes to clean up.
-  const TableMeta *meta = catalog_lookup_meta(tid.value());
+  // Table metadata, for the secondary index ranges to clean up.
+  TableMeta meta;
+  const bool have_meta = catalog_copy_meta(tid.value(), meta);
 
   // Atomic del_range of all row keys + secondary index keys + catalog entry.
   auto lower = table_id_prefix(tid.value());
@@ -388,9 +389,8 @@ int ha_bytecaskdb::delete_table(const char *name) {
   plan.del_range(as_view(lower), as_view(upper));
 
   // Delete all secondary index ranges [0x03 | table_id | index_id].
-  // Schema v2 always has indexes (may be empty)
-  if (meta) {
-    for (const auto &index : meta->indexes) {
+  if (have_meta) {
+    for (const auto &index : meta.indexes) {
       auto idx_lower = index_id_prefix(tid.value(), index.index_id);
       auto idx_upper = index_id_upper_bound(tid.value(), index.index_id);
       plan.del_range(as_view(idx_lower), as_view(idx_upper));
@@ -417,20 +417,16 @@ int ha_bytecaskdb::delete_table(const char *name) {
 int ha_bytecaskdb::delete_all_rows() {
   if (!g_db) { return HA_ERR_GENERIC; }
 
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-
   auto lower = table_id_prefix(table_id_);
   auto upper = table_id_upper_bound(table_id_);
 
   bytecask::WritePlan plan;
   plan.del_range(as_view(lower), as_view(upper));
 
-  if (meta) {
-    for (const auto &index : meta->indexes) {
-      auto idx_lower = index_id_prefix(table_id_, index.index_id);
-      auto idx_upper = index_id_upper_bound(table_id_, index.index_id);
-      plan.del_range(as_view(idx_lower), as_view(idx_upper));
-    }
+  for (const auto &index : indexes_) {
+    auto idx_lower = index_id_prefix(table_id_, index.index_id);
+    auto idx_upper = index_id_upper_bound(table_id_, index.index_id);
+    plan.del_range(as_view(idx_lower), as_view(idx_upper));
   }
 
   try {
@@ -790,8 +786,7 @@ int ha_bytecaskdb::update_row(const uchar *old_data, const uchar *new_data) {
   encode_row_into(new_val, table, new_data, schema_version_);
 
   // Handle secondary indexes.
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (meta) {
+  if (!indexes_.empty()) {
     const uint8_t *pk_bytes     = old_pk.data() + 5;
     const size_t   pk_bytes_len = old_pk.size() - 5;
 
@@ -810,7 +805,7 @@ int ha_bytecaskdb::update_row(const uchar *old_data, const uchar *new_data) {
       return false;
     };
 
-    for (const auto &index : meta->indexes) {
+    for (const auto &index : indexes_) {
       const KEY &ki = table->key_info[index.index_id];
       if (!pk_changing && !index_in_write_set(ki)) continue;
 
@@ -908,13 +903,11 @@ int ha_bytecaskdb::delete_row(const uchar *buf) {
   }
 
   // Buffer secondary index deletions first.
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (meta) {
-    for (const auto &index : meta->indexes) {
-      auto sec_key = encode_sec_key(table, buf, table_id_,
-                                     index.index_id, index.index_id, rowid);
-      txn->buffer_del(sec_key.data(), sec_key.size());
-    }
+  for (const auto &index : indexes_) {
+    auto &sec_key = encode_sec_key_buf_;
+    encode_sec_key_into(sec_key, table, buf, table_id_,
+                        index.index_id, index.index_id, rowid);
+    txn->buffer_del(sec_key.data(), sec_key.size());
   }
 
   FAULT_INJECTION(plugin_after_pk_buffer);
@@ -973,8 +966,7 @@ int ha_bytecaskdb::rnd_end() {
 int ha_bytecaskdb::check(THD * /*thd*/, HA_CHECK_OPT * /*check_opt*/) {
   if (!g_db) return HA_ADMIN_FAILED;
 
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (!meta || meta->indexes.empty())
+  if (indexes_.empty())
     return HA_ADMIN_OK;
 
   auto *txn = txn_cached_;
@@ -987,7 +979,7 @@ int ha_bytecaskdb::check(THD * /*thd*/, HA_CHECK_OPT * /*check_opt*/) {
   bool corrupt = false;
 
   while ((rc = rnd_next(buf)) == 0) {
-    for (const auto &index : meta->indexes) {
+    for (const auto &index : indexes_) {
       // Build the full secondary key (including PK suffix) for this row.
       // For PK-less tables, extract the synthetic rowid from current_row_key_.
       uint64_t rowid = 0;
@@ -1516,17 +1508,16 @@ bool ha_bytecaskdb::inplace_alter_table(TABLE * /*altered_table*/,
                                          Alter_inplace_info *ha_alter_info) {
   if (!g_db) { return true; }
 
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (!meta) { return false; }
+  TableMeta updated;
+  if (!catalog_copy_meta(table_id_, updated)) { return false; }
 
   bool has_drop_fk = (ha_alter_info->handler_flags & ALTER_DROP_FOREIGN_KEY) != 0;
   bool has_rename  = (ha_alter_info->handler_flags & ALTER_COLUMN_NAME) != 0;
 
-  if (meta->fks.empty() && !has_drop_fk) {
+  if (updated.fks.empty() && !has_drop_fk) {
     return false;
   }
 
-  TableMeta updated = *meta;
   pre_alter_fks_ = updated.fks;
 
   // Handle DROP FOREIGN KEY
@@ -1593,10 +1584,8 @@ bool ha_bytecaskdb::commit_inplace_alter_table(TABLE * /*altered_table*/,
   }
 
   // Rollback: restore the original FK list.
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (!meta) { return true; }
-
-  TableMeta restored = *meta;
+  TableMeta restored;
+  if (!catalog_copy_meta(table_id_, restored)) { return true; }
   restored.fks = std::move(pre_alter_fks_);
   restored.schema_version = restored.fks.empty() ? 2 : 3;
 
@@ -1613,10 +1602,10 @@ bool ha_bytecaskdb::commit_inplace_alter_table(TABLE * /*altered_table*/,
 
 int ha_bytecaskdb::get_foreign_key_list(THD *thd,
                                          List<FOREIGN_KEY_INFO> *f_key_list) {
-  const TableMeta *meta = catalog_lookup_meta(table_id_);
-  if (!meta) { return 0; }
+  TableMeta meta;
+  if (!catalog_copy_meta(table_id_, meta)) { return 0; }
 
-  for (const auto &fk : meta->fks) {
+  for (const auto &fk : meta.fks) {
     auto *fk_info = static_cast<FOREIGN_KEY_INFO *>(
         thd_alloc(thd, sizeof(FOREIGN_KEY_INFO)));
     new (fk_info) FOREIGN_KEY_INFO();

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.cc
@@ -26,6 +26,7 @@
 #include <private/service_versions.h>
 #endif
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <exception>
@@ -1099,14 +1100,15 @@ bool key_has_prefix(const MariaDBTxn::MergeIterator &it,
 // then the unsupplied remainder padded in *transformed* space — 0x00 sorts
 // before every stored key sharing the prefix, 0xFF after every one. (Padding
 // before the transform would be wrong: 0xFF bytes through the signed-integer
-// transform encode -1, not the maximum.) For a secondary index padded high
-// the PK suffix is padded with 0xFF as well.
+// transform encode -1, not the maximum.) A high-padded key is extended past
+// any stored key sharing the prefix, so it also sorts after the exact key
+// when the whole key was supplied.
 // Returns the length of namespace + transformed prefix, i.e. the bytes a
 // stored key must share to "have the prefix".
-std::size_t ha_bytecaskdb::build_search_key(const uchar *key, uint prefix_len,
-                                            bool pad_high) {
-  const bool on_pk = (active_index == table->s->primary_key);
-  const KEY &key_info = table->key_info[active_index];
+std::size_t ha_bytecaskdb::build_search_key(uint idx, const uchar *key,
+                                            uint prefix_len, bool pad_high) {
+  const bool on_pk = (idx == table->s->primary_key);
+  const KEY &key_info = table->key_info[idx];
   const uint key_len = key_info.key_length;
   const std::size_t ns_len = on_pk ? 5 : 7;
 
@@ -1115,8 +1117,8 @@ std::size_t ha_bytecaskdb::build_search_key(const uchar *key, uint prefix_len,
   p[0] = on_pk ? kNsRow : kNsIndex;
   write_table_id_prefix(p + 1, table_id_);
   if (!on_pk) {
-    p[5] = static_cast<uint8_t>((active_index >> 8) & 0xFF);
-    p[6] = static_cast<uint8_t>( active_index       & 0xFF);
+    p[5] = static_cast<uint8_t>((idx >> 8) & 0xFF);
+    p[6] = static_cast<uint8_t>( idx       & 0xFF);
   }
 
   uint8_t *kp = p + ns_len;
@@ -1128,15 +1130,17 @@ std::size_t ha_bytecaskdb::build_search_key(const uchar *key, uint prefix_len,
   if (on_pk) {
     normalize_padspace_pk(kp, &key_info);
   } else {
-    fix_varchar_key_encoding(kp, table, active_index);
+    fix_varchar_key_encoding(kp, table, idx);
   }
   make_mem_comparable(kp, &key_info, prefix_len);
 
   if (pad_high) {
     std::memset(kp + prefix_len, 0xFF, key_len - prefix_len);
-    if (!on_pk) {
-      search_key_buf_.resize(ns_len + key_len + pk_suffix_length(table), 0xFF);
-    }
+    // Sort after every stored key carrying the prefix, including the key
+    // itself when the whole key was supplied: a secondary entry continues
+    // with its PK suffix, a PK key with nothing, so extend past both.
+    const std::size_t tail = on_pk ? 1 : pk_suffix_length(table);
+    search_key_buf_.resize(ns_len + key_len + tail, 0xFF);
   }
   return ns_len + prefix_len;
 }
@@ -1162,7 +1166,7 @@ int ha_bytecaskdb::index_read_map(uchar *buf, const uchar *key,
 
   const SeekMode mode = seek_mode_for(find_flag);
   const std::size_t ns_prefix_len =
-      build_search_key(key, prefix_len, mode.pad_high);
+      build_search_key(active_index, key, prefix_len, mode.pad_high);
 
   // Transformed prefix, used by index_next_same and the prefix rules below.
   sec_search_key_.assign(search_key_buf_.begin(),
@@ -1461,13 +1465,75 @@ int ha_bytecaskdb::info(uint flag) {
 }
 
 // ---------------------------------------------------------------------------
-// records_in_range() — estimate rows in key range for optimizer
+// records_in_range() — row estimate for the optimizer.
+//
+// Key enumeration is an in-memory tree walk, so a selective range is
+// counted exactly (merged with this transaction's buffered writes) up to
+// kRangeCountCap keys. Above the cap the walk stops and the estimate falls
+// back to a fixed fraction of the table, which is all the optimizer needs
+// to rank a wide range against a narrow one. Never returns 0: the server
+// treats 0 as an exact "empty" answer.
 // ---------------------------------------------------------------------------
 
-ha_rows ha_bytecaskdb::records_in_range(uint /*index*/, const key_range */*min_key*/,
-                                         const key_range */*max_key*/,
-                                         page_range */*pages*/) {
-  return stats.records > 0 ? std::max(ha_rows(2), stats.records / 10) : 2;
+namespace {
+constexpr ha_rows kRangeCountCap = 1024;
+
+// Number of supplied bytes in a key_range: keypart_map marks whole leading
+// parts, the same way index_read_map interprets it.
+uint supplied_key_bytes(const KEY &key_info, const key_range *r) {
+  uint len = 0;
+  for (uint i = 0; i < key_info.user_defined_key_parts; ++i) {
+    if (!(r->keypart_map & (key_part_map(1) << i))) break;
+    len += key_info.key_part[i].store_length;
+  }
+  return len;
+}
+}  // namespace
+
+ha_rows ha_bytecaskdb::records_in_range(uint index, const key_range *min_key,
+                                         const key_range *max_key,
+                                         page_range * /*pages*/) {
+  const ha_rows fallback =
+      stats.records > 0 ? std::max(ha_rows(2), stats.records / 10) : 2;
+  auto *txn = txn_cached_;
+  if (!g_db || !txn) { return fallback; }
+
+  const bool on_pk = (index == table->s->primary_key);
+  const KEY &key_info = table->key_info[index];
+  const auto idx = static_cast<uint16_t>(index);
+
+  // Lower bound: >= key (KEY_EXACT / KEY_OR_NEXT) pads low, > key
+  // (AFTER_KEY) pads high so every key carrying the prefix sorts before it.
+  std::vector<uint8_t> lo;
+  if (min_key) {
+    build_search_key(index, min_key->key, supplied_key_bytes(key_info, min_key),
+                     min_key->flag == HA_READ_AFTER_KEY);
+    lo = search_key_buf_;
+  } else {
+    lo = on_pk ? table_id_prefix(table_id_) : index_id_prefix(table_id_, idx);
+  }
+  // Upper bound (exclusive in the scan): <= key (AFTER_KEY) pads high so
+  // the prefix's keys stay below it, < key (BEFORE_KEY) pads low.
+  std::vector<uint8_t> hi;
+  if (max_key) {
+    build_search_key(index, max_key->key, supplied_key_bytes(key_info, max_key),
+                     max_key->flag == HA_READ_AFTER_KEY);
+    hi = search_key_buf_;
+  } else {
+    hi = on_pk ? table_id_upper_bound(table_id_)
+               : index_id_upper_bound(table_id_, idx);
+  }
+
+  auto it = on_pk
+      ? txn->iter_prefix(lo.data(), lo.size(), hi.data(), hi.size(), table_id_)
+      : txn->iter_index_prefix(lo.data(), lo.size(), hi.data(), hi.size(),
+                               table_id_, idx);
+  if (!it) { return fallback; }
+
+  ha_rows n = 0;
+  for (; it->valid() && n < kRangeCountCap; it->next()) { ++n; }
+  if (n >= kRangeCountCap) { return std::max(kRangeCountCap, fallback); }
+  return std::max(ha_rows(1), n);
 }
 
 // ---------------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -102,6 +102,12 @@ public:
   // with a durability barrier before the ALTER proceeds to the rename.
   int end_bulk_insert() override;
 
+  // Raises ER_DUP_ENTRY for the encoded primary key `pk` with the server's
+  // standard message, and records the PK as the duplicate key for
+  // get_dup_key(). Called by MariaDBTxn when a deferred INSERT's
+  // commit-time ensure_absent guard fails; see begin_deferred_insert.
+  void report_dup_pk(const std::vector<uint8_t> &pk);
+
   // -------------------------------------------------------------------
   // Full table scan
   // -------------------------------------------------------------------

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -214,6 +214,10 @@ private:
   // Saves `current_row_key_` from a slice the iterator gave us.
   void save_current_row_key(const uint8_t *data, std::size_t len);
   int index_read_current(uchar *buf);
+  // Encodes the optimizer's (partial) key for the active index into
+  // search_key_buf_, padding unsupplied parts low or high. Returns the
+  // length of namespace + supplied prefix. See index_read_map.
+  std::size_t build_search_key(const uchar *key, uint prefix_len, bool pad_high);
 
   // True when this handler is the destination of an ALTER TABLE copy into a
   // hidden #sql-xxx table — the case where write_row switches to batched

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -44,7 +44,10 @@ bool             catalog_rename_table_meta(bytecask::DB *db,
                                            const char *from,
                                            const char *to);
 std::optional<uint32_t> catalog_lookup_table_id(const char *name);
-const TableMeta *catalog_lookup_meta(uint32_t table_id);
+// Copies the table's metadata out under the catalog lock. Returns false if
+// the table is unknown. Handlers cache what they need at open(); DDL paths
+// take a fresh copy. No reference into the catalog cache is ever handed out.
+bool             catalog_copy_meta(uint32_t table_id, TableMeta &out);
 
 uint64_t         catalog_alloc_rowid(uint32_t table_id);
 uint64_t         catalog_alloc_rowid_range(uint32_t table_id, uint64_t count);

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -106,7 +106,8 @@ public:
   // standard message, and records the PK as the duplicate key for
   // get_dup_key(). Called by MariaDBTxn when a deferred INSERT's
   // commit-time ensure_absent guard fails; see begin_deferred_insert.
-  void report_dup_pk(const std::vector<uint8_t> &pk);
+  // Returns false without reporting if `pk` is not this table's key.
+  bool report_dup_pk(const std::vector<uint8_t> &pk);
 
   // -------------------------------------------------------------------
   // Full table scan

--- a/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
+++ b/bytecaskdb-mariadb-plugin/ha_bytecaskdb.h
@@ -224,10 +224,11 @@ private:
   // Saves `current_row_key_` from a slice the iterator gave us.
   void save_current_row_key(const uint8_t *data, std::size_t len);
   int index_read_current(uchar *buf);
-  // Encodes the optimizer's (partial) key for the active index into
+  // Encodes the optimizer's (partial) key for index `idx` into
   // search_key_buf_, padding unsupplied parts low or high. Returns the
   // length of namespace + supplied prefix. See index_read_map.
-  std::size_t build_search_key(const uchar *key, uint prefix_len, bool pad_high);
+  std::size_t build_search_key(uint idx, const uchar *key, uint prefix_len,
+                               bool pad_high);
 
   // True when this handler is the destination of an ALTER TABLE copy into a
   // hidden #sql-xxx table — the case where write_row switches to batched

--- a/bytecaskdb-mariadb-plugin/tests/functional/cases/index_scan_completeness.yaml
+++ b/bytecaskdb-mariadb-plugin/tests/functional/cases/index_scan_completeness.yaml
@@ -51,3 +51,90 @@
       expected: [['1','2'],['2','3'],['3','4'],['4','5'],['5','6'],['5','100'],['10','11'],['101','102'],['1000','100'],['10001','103']]
   teardown:
     - DROP DATABASE IF EXISTS isc4
+
+- name: Descending PK range inside a transaction merges uncommitted rows (BC-250)
+  setup:
+    - DROP DATABASE IF EXISTS isc_rev1
+    - CREATE DATABASE isc_rev1
+    - CREATE TABLE isc_rev1.t (id INT PRIMARY KEY, v INT) ENGINE=bytecaskdb
+    - INSERT INTO isc_rev1.t VALUES (1,10),(3,30),(5,50),(7,70),(12,120)
+  steps:
+    - sql: BEGIN
+    - sql: INSERT INTO isc_rev1.t VALUES (2,20),(8,80),(11,110)
+    - sql: DELETE FROM isc_rev1.t WHERE id = 5
+    - sql: UPDATE isc_rev1.t SET v = 33 WHERE id = 3
+    - sql: SELECT id, v FROM isc_rev1.t WHERE id < 10 ORDER BY id DESC
+      expected: [['8','80'],['7','70'],['3','33'],['2','20'],['1','10']]
+    - sql: SELECT id, v FROM isc_rev1.t WHERE id <= 8 ORDER BY id DESC
+      expected: [['8','80'],['7','70'],['3','33'],['2','20'],['1','10']]
+    - sql: SELECT id FROM isc_rev1.t WHERE id > 3 ORDER BY id
+      expected: [['7'],['8'],['11'],['12']]
+    - sql: SELECT id FROM isc_rev1.t ORDER BY id DESC
+      expected: [['12'],['11'],['8'],['7'],['3'],['2'],['1']]
+    - sql: COMMIT
+    - sql: SELECT id FROM isc_rev1.t WHERE id < 10 ORDER BY id DESC
+      expected: [['8'],['7'],['3'],['2'],['1']]
+  teardown:
+    - DROP DATABASE IF EXISTS isc_rev1
+
+- name: Descending secondary-index range inside a transaction merges uncommitted rows (BC-250)
+  setup:
+    - DROP DATABASE IF EXISTS isc_rev2
+    - CREATE DATABASE isc_rev2
+    - CREATE TABLE isc_rev2.t (id INT PRIMARY KEY, k INT NOT NULL, INDEX idx_k(k)) ENGINE=bytecaskdb
+    - INSERT INTO isc_rev2.t VALUES (1,10),(2,30),(3,50),(4,70),(5,120)
+  steps:
+    - sql: BEGIN
+    - sql: INSERT INTO isc_rev2.t VALUES (6,20),(7,80),(8,110)
+    - sql: DELETE FROM isc_rev2.t WHERE id = 3
+    - sql: SELECT k FROM isc_rev2.t FORCE INDEX (idx_k) WHERE k < 100 ORDER BY k DESC
+      expected: [['80'],['70'],['30'],['20'],['10']]
+    - sql: SELECT k FROM isc_rev2.t FORCE INDEX (idx_k) WHERE k <= 80 ORDER BY k DESC
+      expected: [['80'],['70'],['30'],['20'],['10']]
+    - sql: SELECT k FROM isc_rev2.t FORCE INDEX (idx_k) WHERE k > 30 ORDER BY k
+      expected: [['70'],['80'],['110'],['120']]
+    - sql: SELECT k FROM isc_rev2.t FORCE INDEX (idx_k) WHERE k >= 30 ORDER BY k DESC LIMIT 2
+      expected: [['120'],['110']]
+    - sql: COMMIT
+  teardown:
+    - DROP DATABASE IF EXISTS isc_rev2
+
+- name: Composite PK prefix lookups (exact prefix, last in prefix) (BC-250)
+  setup:
+    - DROP DATABASE IF EXISTS isc_cpk
+    - CREATE DATABASE isc_cpk
+    - CREATE TABLE isc_cpk.t (a INT NOT NULL, b INT NOT NULL, v INT, PRIMARY KEY (a, b)) ENGINE=bytecaskdb
+    - INSERT INTO isc_cpk.t VALUES (1,1,11),(1,2,12),(1,3,13),(2,1,21),(2,5,25),(3,1,31)
+  steps:
+    - sql: SELECT b FROM isc_cpk.t WHERE a = 2 ORDER BY b
+      expected: [['1'],['5']]
+    - sql: SELECT b FROM isc_cpk.t WHERE a = 1 ORDER BY b DESC LIMIT 1
+      expected: [['3']]
+    - sql: SELECT a, b FROM isc_cpk.t WHERE a = 2 ORDER BY b DESC
+      expected: [['2','5'],['2','1']]
+    - sql: SELECT a, b FROM isc_cpk.t WHERE a < 3 ORDER BY a DESC, b DESC
+      expected: [['2','5'],['2','1'],['1','3'],['1','2'],['1','1']]
+    - sql: SELECT a, b FROM isc_cpk.t WHERE a > 1 ORDER BY a, b
+      expected: [['2','1'],['2','5'],['3','1']]
+    - sql: SELECT COUNT(*) FROM isc_cpk.t WHERE a = 4
+      expected: [['0']]
+  teardown:
+    - DROP DATABASE IF EXISTS isc_cpk
+
+- name: Descending PK scan is complete when the neighbouring table id has rows (engine riter_from fix)
+  setup:
+    - DROP DATABASE IF EXISTS isc_nb
+    - CREATE DATABASE isc_nb
+    - CREATE TABLE isc_nb.first (id INT PRIMARY KEY) ENGINE=bytecaskdb
+    - CREATE TABLE isc_nb.second (id INT PRIMARY KEY) ENGINE=bytecaskdb
+    - INSERT INTO isc_nb.first VALUES (1),(2),(3)
+    - INSERT INTO isc_nb.second VALUES (1),(2),(3)
+  steps:
+    - sql: SELECT id FROM isc_nb.first ORDER BY id DESC
+      expected: [['3'],['2'],['1']]
+    - sql: SELECT id FROM isc_nb.first ORDER BY id DESC LIMIT 1
+      expected: [['3']]
+    - sql: SELECT MAX(id) FROM isc_nb.first
+      expected: [['3']]
+  teardown:
+    - DROP DATABASE IF EXISTS isc_nb

--- a/bytecaskdb-mariadb-plugin/tests/functional/cases/savepoint.yaml
+++ b/bytecaskdb-mariadb-plugin/tests/functional/cases/savepoint.yaml
@@ -77,3 +77,23 @@
         - [3, 30]
   teardown:
     - DROP DATABASE IF EXISTS sp4
+
+- name: ROLLBACK TO SAVEPOINT restores the table row count (BC-253)
+  setup:
+    - DROP DATABASE IF EXISTS sp5
+    - CREATE DATABASE sp5
+    - CREATE TABLE sp5.t (id INT PRIMARY KEY, v INT NOT NULL) ENGINE=bytecaskdb
+  steps:
+    - sql: BEGIN
+    - sql: INSERT INTO sp5.t VALUES (1, 10)
+    - sql: SAVEPOINT s1
+    - sql: INSERT INTO sp5.t VALUES (2, 20), (3, 30)
+    - sql: ROLLBACK TO SAVEPOINT s1
+    - sql: INSERT INTO sp5.t VALUES (4, 40)
+    - sql: COMMIT
+    - sql: SELECT COUNT(*) FROM sp5.t
+      expected: [['2']]
+    - sql: SELECT TABLE_ROWS FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'sp5' AND TABLE_NAME = 't'
+      expected: [['2']]
+  teardown:
+    - DROP DATABASE IF EXISTS sp5

--- a/bytecaskdb-mariadb-plugin/tests/functional/cases/transactions.yaml
+++ b/bytecaskdb-mariadb-plugin/tests/functional/cases/transactions.yaml
@@ -109,3 +109,23 @@
       expected: [['42']]
   teardown:
     - DROP DATABASE IF EXISTS txn7
+
+- name: Failed statement inside transaction keeps earlier statements (BC-249)
+  setup:
+    - DROP DATABASE IF EXISTS txn_stmt_rb
+    - CREATE DATABASE txn_stmt_rb
+    - CREATE TABLE txn_stmt_rb.t (id INT PRIMARY KEY, v INT NOT NULL) ENGINE=bytecaskdb
+    - INSERT INTO txn_stmt_rb.t VALUES (99, 0)
+  steps:
+    - sql: BEGIN
+    - sql: INSERT INTO txn_stmt_rb.t VALUES (1, 10)
+    - sql: INSERT INTO txn_stmt_rb.t VALUES (2, 20)
+    - sql: INSERT INTO txn_stmt_rb.t VALUES (3, 30), (99, 1)
+      error: 1062
+    - sql: COMMIT
+    - sql: SELECT id, v FROM txn_stmt_rb.t ORDER BY id
+      expected: [['1','10'],['2','20'],['99','0']]
+    - sql: SELECT COUNT(*) FROM txn_stmt_rb.t
+      expected: [['3']]
+  teardown:
+    - DROP DATABASE IF EXISTS txn_stmt_rb

--- a/bytecaskdb-mariadb-plugin/tests/functional/cases/transactions.yaml
+++ b/bytecaskdb-mariadb-plugin/tests/functional/cases/transactions.yaml
@@ -129,3 +129,24 @@
       expected: [['3']]
   teardown:
     - DROP DATABASE IF EXISTS txn_stmt_rb
+
+- name: INSERT with a trigger writing another table keeps duplicate detection and audit rows consistent
+  setup:
+    - DROP DATABASE IF EXISTS trg1
+    - CREATE DATABASE trg1
+    - CREATE TABLE trg1.t (id INT PRIMARY KEY, v INT) ENGINE=bytecaskdb
+    - CREATE TABLE trg1.audit (id INT PRIMARY KEY AUTO_INCREMENT, t_id INT) ENGINE=bytecaskdb
+    - CREATE TRIGGER trg1.t_ai AFTER INSERT ON trg1.t FOR EACH ROW INSERT INTO trg1.audit (t_id) VALUES (NEW.id)
+    - INSERT INTO trg1.t VALUES (1, 10)
+  steps:
+    - sql: INSERT INTO trg1.t VALUES (2, 20)
+    - sql: INSERT INTO trg1.t VALUES (1, 11)
+      error: 1062
+    - sql: INSERT INTO trg1.t VALUES (3, 30), (2, 22)
+      error: 1062
+    - sql: SELECT id, v FROM trg1.t ORDER BY id
+      expected: [['1','10'],['2','20']]
+    - sql: SELECT t_id FROM trg1.audit ORDER BY id
+      expected: [['1'],['2']]
+  teardown:
+    - DROP DATABASE IF EXISTS trg1

--- a/bytecaskdb-mariadb-plugin/tests/functional/runner.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/runner.py
@@ -55,6 +55,10 @@ def _execute_step(cur, step, case_name):
         )
 
     cur.execute(sql)
+    if step.get("expected") == "discard":
+        # Statement must succeed; its rows are not compared (EXPLAIN output).
+        cur.fetchall()
+        return
     if "expected" in step:
         actual = _rows_to_str(cur.fetchall())
         expected = [["NULL" if v is None else str(v) for v in row] for row in step["expected"]]

--- a/bytecaskdb-mariadb-plugin/tests/functional/test_concurrency.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/test_concurrency.py
@@ -245,3 +245,62 @@ def test_high_concurrency_inserts(make_connection):
 
     assert not errors, f"Insert errors: {errors}"
     assert total == 1600, f"Expected 1600 rows, got {total}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Autocommit read-modify-write must not lose updates
+# ---------------------------------------------------------------------------
+
+def test_autocommit_increment_no_lost_update(make_connection):
+    """
+    8 connections each run `UPDATE ... SET v = v + 1` 100 times in autocommit,
+    retrying on 1213. Every increment must land: the statement's read and its
+    write must be checked against the same snapshot, so a concurrent commit
+    between the two surfaces as a conflict rather than being overwritten.
+    """
+    n_threads, n_iters = 8, 100
+    _setup(
+        make_connection,
+        "DROP DATABASE IF EXISTS conc_rmw",
+        "CREATE DATABASE conc_rmw",
+        "CREATE TABLE conc_rmw.t (id INT PRIMARY KEY, v INT NOT NULL) ENGINE=bytecaskdb",
+        "INSERT INTO conc_rmw.t VALUES (1, 0)",
+    )
+
+    errors = []
+    barrier = threading.Barrier(n_threads)
+
+    def incrementer():
+        conn = make_connection()
+        try:
+            with conn.cursor() as cur:
+                barrier.wait()
+                for _ in range(n_iters):
+                    while True:
+                        try:
+                            cur.execute("UPDATE conc_rmw.t SET v = v + 1 WHERE id = 1")
+                            break
+                        except pymysql.err.OperationalError as e:
+                            if e.args[0] not in (1180, 1213):
+                                raise
+        except Exception as e:
+            errors.append(e)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=incrementer) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    conn = make_connection()
+    with conn.cursor() as cur:
+        cur.execute("SELECT v FROM conc_rmw.t WHERE id = 1")
+        (v,) = cur.fetchone()
+    conn.close()
+
+    _teardown(make_connection, "DROP DATABASE IF EXISTS conc_rmw")
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert v == n_threads * n_iters, f"Lost updates: expected {n_threads * n_iters}, got {v}"

--- a/bytecaskdb-mariadb-plugin/tests/functional/test_dup_key_message.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/test_dup_key_message.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2026 Gustavo Amigo
+#
+# test_dup_key_message.py — duplicate-key errors carry the standard code and
+# message on every INSERT path, including the deferred (commit-time) check
+# used for plain autocommit INSERTs.
+
+import pytest
+import pymysql
+
+
+def _run(make_connection, *sqls):
+    conn = make_connection()
+    try:
+        with conn.cursor() as cur:
+            for sql in sqls:
+                cur.execute(sql)
+    finally:
+        conn.close()
+
+
+def _expect_dup(cur, sql, value, key="PRIMARY"):
+    with pytest.raises(pymysql.err.IntegrityError) as ei:
+        cur.execute(sql)
+    code, msg = ei.value.args[0], ei.value.args[1]
+    assert code == 1062, f"expected ER_DUP_ENTRY (1062), got {code}: {msg}"
+    assert f"Duplicate entry '{value}' for key '{key}'" in msg, msg
+
+
+def test_duplicate_pk_message_on_all_insert_paths(make_connection):
+    _run(
+        make_connection,
+        "DROP DATABASE IF EXISTS dupmsg",
+        "CREATE DATABASE dupmsg",
+        "CREATE TABLE dupmsg.t (id INT PRIMARY KEY, v VARCHAR(16)) ENGINE=bytecaskdb",
+        "CREATE TABLE dupmsg.c (a INT NOT NULL, b VARCHAR(8) NOT NULL, v INT, PRIMARY KEY (a, b)) ENGINE=bytecaskdb",
+        "INSERT INTO dupmsg.t VALUES (7, 'seven')",
+        "INSERT INTO dupmsg.c VALUES (1, 'x', 0)",
+    )
+    conn = make_connection()
+    try:
+        with conn.cursor() as cur:
+            # Plain autocommit INSERT: deferred check, reported at commit.
+            _expect_dup(cur, "INSERT INTO dupmsg.t VALUES (7, 'again')", "7")
+            # Multi-row: the duplicate is the second row.
+            _expect_dup(cur, "INSERT INTO dupmsg.t VALUES (8, 'eight'), (7, 'again')", "7")
+            # Composite PK renders as 'a-b'.
+            _expect_dup(cur, "INSERT INTO dupmsg.c VALUES (1, 'x', 1)", "1-x")
+            # Explicit transaction: eager check inside write_row.
+            cur.execute("BEGIN")
+            _expect_dup(cur, "INSERT INTO dupmsg.t VALUES (7, 'again')", "7")
+            cur.execute("ROLLBACK")
+            # Nothing leaked from the failed statements.
+            cur.execute("SELECT id, v FROM dupmsg.t ORDER BY id")
+            assert cur.fetchall() == ((7, "seven"),)
+    finally:
+        conn.close()
+    _run(make_connection, "DROP DATABASE IF EXISTS dupmsg")

--- a/bytecaskdb-mariadb-plugin/tests/functional/test_records_in_range.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/test_records_in_range.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2026 Gustavo Amigo
+#
+# test_records_in_range.py — the optimizer's row estimate for a key range is
+# an exact count for selective ranges (PK and secondary index), including
+# rows buffered in the current transaction.
+
+import pymysql
+
+
+def _explain_rows(cur, sql):
+    cur.execute("EXPLAIN " + sql)
+    row = cur.fetchone()
+    # id, select_type, table, type, possible_keys, key, key_len, ref, rows, Extra
+    return row[3], int(row[8])
+
+
+def test_range_estimates_are_exact_for_selective_ranges(make_connection):
+    conn = make_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DROP DATABASE IF EXISTS rir")
+            cur.execute("CREATE DATABASE rir")
+            cur.execute(
+                "CREATE TABLE rir.t (id INT PRIMARY KEY, k INT NOT NULL, INDEX idx_k (k)) "
+                "ENGINE=bytecaskdb"
+            )
+            cur.execute(
+                "INSERT INTO rir.t VALUES "
+                + ",".join(f"({i}, {i % 50})" for i in range(1, 501))
+            )
+            cur.execute("ANALYZE TABLE rir.t")
+            cur.fetchall()
+
+            # PK ranges: inclusive, exclusive, and open-ended.
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t WHERE id BETWEEN 10 AND 14")
+            assert typ == "range" and rows == 5, (typ, rows)
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t WHERE id > 490")
+            assert rows == 10, (typ, rows)
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t WHERE id < 4")
+            assert rows == 3, (typ, rows)
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t WHERE id >= 100 AND id < 103")
+            assert rows == 3, (typ, rows)
+
+            # Secondary index: each k value has 10 rows.
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t FORCE INDEX (idx_k) WHERE k = 7")
+            assert rows == 10, (typ, rows)
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t FORCE INDEX (idx_k) WHERE k BETWEEN 7 AND 8")
+            assert rows == 20, (typ, rows)
+
+            # Uncommitted rows in this transaction count too.
+            cur.execute("BEGIN")
+            cur.execute("INSERT INTO rir.t VALUES (1001, 7), (1002, 7)")
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t FORCE INDEX (idx_k) WHERE k = 7")
+            assert rows == 12, (typ, rows)
+            typ, rows = _explain_rows(cur, "SELECT id FROM rir.t WHERE id > 1000")
+            assert rows == 2, (typ, rows)
+            cur.execute("ROLLBACK")
+
+            cur.execute("DROP DATABASE IF EXISTS rir")
+    finally:
+        conn.close()

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_stubs.h
@@ -358,6 +358,13 @@ inline void my_error(int error, unsigned long /*flags*/, ...) {
   g_stub_last_my_error_code = error;
 }
 
+// Stub: my_printf_error — records the code like my_error; format ignored.
+inline void my_printf_error(int error, const char * /*format*/,
+                            unsigned long /*flags*/, ...) {
+  g_stub_last_my_error_code = error;
+}
+#define ER_THD_OR_DEFAULT(thd, X) ""
+
 // MariaDB error codes.
 #define ER_LOCK_DEADLOCK 1213
 #define ER_DUP_ENTRY 1062

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -386,25 +386,24 @@ TEST_CASE_METHOD(MariaDBTxnFixture, "MariaDBTxn deferred insert dup check",
   }
 
   SECTION("commit-time conflict returns HA_ERR_FOUND_DUPP_KEY and raises "
-          "ER_DUP_ENTRY_WITH_KEY_NAME") {
+          "ER_DUP_ENTRY (1062), the code clients check for") {
     auto txn = create_txn();
     THD thd{};
 
     g_stub_last_my_error_code = 0;
 
-    txn->begin_deferred_insert();
+    txn->begin_deferred_insert(nullptr, nullptr);
     txn->buffer_put(pk.data(), pk.size(), val2.data(), val2.size(),
                     /*guard_absent=*/true);
 
     int rc = txn->commit(&thd, true);
 
     REQUIRE(rc == HA_ERR_FOUND_DUPP_KEY);
-    // ER_DUP_ENTRY's second format placeholder is an integer key index, not
-    // a string — passing a key name there is undefined behavior on the
-    // varargs call and produces a garbled message at runtime. Regression
-    // coverage for that bug: assert the code actually raised is the
-    // two-string variant the (value, key-name) args match.
-    REQUIRE(g_stub_last_my_error_code == ER_DUP_ENTRY_WITH_KEY_NAME);
+    // The server pairs code ER_DUP_ENTRY with the WITH_KEY_NAME message
+    // format; the code must stay 1062 because drivers and ORMs key their
+    // duplicate-key handling on it. (Using ER_DUP_ENTRY's *own* format with
+    // a key-name string is UB: its second placeholder is an integer.)
+    REQUIRE(g_stub_last_my_error_code == ER_DUP_ENTRY);
   }
 }
 

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -583,3 +583,68 @@ TEST_CASE_METHOD(MariaDBTxnFixture, "MariaDBTxn bulk copy mode", "[txn][bulk]") 
     REQUIRE_FALSE(txn->in_bulk_copy());
   }
 }
+
+// =========================================================================
+// Statement rollback inside a multi-statement transaction (BC-249)
+// =========================================================================
+
+TEST_CASE_METHOD(MariaDBTxnFixture,
+                 "MariaDBTxn statement rollback keeps earlier statements",
+                 "[txn][rollback][statement]") {
+  auto k1 = make_key("row:1");
+  auto k2 = make_key("row:2");
+  auto k3 = make_key("row:3");
+  auto v = make_value("x");
+  THD thd{};
+  handlerton hton{};
+  std::atomic<int64_t> rows{0};
+
+  g_stub_thd_options = OPTION_BEGIN;
+  auto txn = create_txn();
+
+  // Statement 1: insert row:1.
+  txn->begin_if_needed(&thd, &hton);
+  txn->buffer_put(k1.data(), k1.size(), v.data(), v.size());
+  txn->track_row_count_delta(7, &rows, 1);
+  REQUIRE(txn->commit(&thd, false) == 0);
+
+  // Statement 2: insert row:2.
+  txn->begin_if_needed(&thd, &hton);
+  txn->buffer_put(k2.data(), k2.size(), v.data(), v.size());
+  txn->track_row_count_delta(7, &rows, 1);
+  REQUIRE(txn->commit(&thd, false) == 0);
+
+  // Statement 3: buffers row:3 and a delete of row:1, then fails.
+  txn->begin_if_needed(&thd, &hton);
+  txn->buffer_put(k3.data(), k3.size(), v.data(), v.size());
+  txn->track_row_count_delta(7, &rows, 1);
+  txn->buffer_del(k1.data(), k1.size());
+  txn->track_row_count_delta(7, &rows, -1);
+  REQUIRE(rows.load() == 2);
+  txn->rollback(&thd, false);
+
+  SECTION("only the failed statement's work is undone") {
+    REQUIRE(txn->exists(k1.data(), k1.size()));
+    REQUIRE(txn->exists(k2.data(), k2.size()));
+    REQUIRE_FALSE(txn->exists(k3.data(), k3.size()));
+    REQUIRE(rows.load() == 2);
+  }
+
+  SECTION("session commit persists statements 1 and 2") {
+    REQUIRE(txn->commit(&thd, true) == 0);
+    auto probe = create_txn();
+    REQUIRE(probe->exists(k1.data(), k1.size()));
+    REQUIRE(probe->exists(k2.data(), k2.size()));
+    REQUIRE_FALSE(probe->exists(k3.data(), k3.size()));
+    REQUIRE(rows.load() == 2);
+  }
+
+  SECTION("session rollback after a statement rollback reverts everything") {
+    txn->rollback(&thd, true);
+    REQUIRE(rows.load() == 0);
+    auto probe = create_txn();
+    REQUIRE_FALSE(probe->exists(k1.data(), k1.size()));
+  }
+
+  g_stub_thd_options = 0;
+}

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -732,3 +732,67 @@ TEST_CASE_METHOD(MariaDBTxnFixture,
     REQUIRE(collect_keys(*it) == std::vector<uint8_t>{3, 1});
   }
 }
+
+// =========================================================================
+// Savepoints restore the row counters, not only the op log
+// =========================================================================
+
+TEST_CASE_METHOD(MariaDBTxnFixture,
+                 "MariaDBTxn savepoint rollback restores row counts",
+                 "[txn][savepoint]") {
+  auto k1 = make_key("r:1");
+  auto k2 = make_key("r:2");
+  auto k3 = make_key("r:3");
+  auto v = make_value("x");
+  THD thd{};
+  std::atomic<int64_t> rows{0};
+  uint32_t sp1 = 0, sp2 = 0;
+
+  auto txn = create_txn();
+  txn->buffer_put(k1.data(), k1.size(), v.data(), v.size());
+  txn->track_row_count_delta(1, &rows, 1);
+
+  txn->savepoint_set(&sp1);
+  txn->buffer_put(k2.data(), k2.size(), v.data(), v.size());
+  txn->track_row_count_delta(1, &rows, 1);
+
+  txn->savepoint_set(&sp2);
+  txn->buffer_put(k3.data(), k3.size(), v.data(), v.size());
+  txn->track_row_count_delta(1, &rows, 1);
+  REQUIRE(rows.load() == 3);
+
+  SECTION("rollback to the inner savepoint") {
+    txn->savepoint_rollback(&sp2);
+    REQUIRE(rows.load() == 2);
+    REQUIRE(txn->exists(k2.data(), k2.size()));
+    REQUIRE_FALSE(txn->exists(k3.data(), k3.size()));
+  }
+
+  SECTION("rollback to the outer savepoint, then keep working") {
+    txn->savepoint_rollback(&sp1);
+    REQUIRE(rows.load() == 1);
+    REQUIRE_FALSE(txn->exists(k2.data(), k2.size()));
+
+    txn->buffer_put(k3.data(), k3.size(), v.data(), v.size());
+    txn->track_row_count_delta(1, &rows, 1);
+    REQUIRE(rows.load() == 2);
+
+    // The savepoint survives ROLLBACK TO and can be rolled back to again.
+    txn->savepoint_rollback(&sp1);
+    REQUIRE(rows.load() == 1);
+    REQUIRE_FALSE(txn->exists(k3.data(), k3.size()));
+  }
+
+  SECTION("release keeps the work and the counters") {
+    txn->savepoint_release(&sp1);
+    REQUIRE(rows.load() == 3);
+    REQUIRE(txn->commit(&thd, true) == 0);
+    REQUIRE(rows.load() == 3);
+  }
+
+  SECTION("full rollback after a savepoint rollback reverts everything") {
+    txn->savepoint_rollback(&sp2);
+    txn->rollback(&thd, true);
+    REQUIRE(rows.load() == 0);
+  }
+}

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -309,6 +309,62 @@ TEST_CASE_METHOD(MariaDBTxnFixture, "MariaDBTxn commit rollback", "[txn][commit]
 }
 
 // =========================================================================
+// Autocommit read-modify-write: the snapshot must predate the read
+// =========================================================================
+
+TEST_CASE_METHOD(MariaDBTxnFixture,
+                 "MariaDBTxn autocommit read pins the OCC snapshot",
+                 "[txn][occ][autocommit]") {
+  auto key = make_key("counter:1");
+  auto v0 = make_value("0");
+  auto v1 = make_value("1");
+  THD thd{};
+
+  // Seed the row.
+  {
+    auto seed = create_txn();
+    seed->buffer_put(key.data(), key.size(), v0.data(), v0.size());
+    REQUIRE(seed->commit(&thd, true) == 0);
+  }
+
+  // No begin_if_needed: this is autocommit, where the handler's first call
+  // on the statement is the point read (index_read_map -> get).
+  auto a = create_txn();
+  auto b = create_txn();
+
+  SECTION("get() then concurrent commit then write conflicts") {
+    bytecask::Bytes out;
+    REQUIRE(a->get(key.data(), key.size(), out) == 1);
+    REQUIRE(a->is_active());  // snapshot taken by the read, not the write
+
+    b->buffer_put(key.data(), key.size(), v1.data(), v1.size());
+    REQUIRE(b->commit(&thd, true) == 0);
+
+    // A computes its new value from the stale read and writes it back.
+    a->buffer_put(key.data(), key.size(), v1.data(), v1.size());
+    REQUIRE(a->commit(&thd, true) == HA_ERR_LOCK_DEADLOCK);
+  }
+
+  SECTION("exists() then concurrent commit then write conflicts") {
+    REQUIRE(a->exists(key.data(), key.size()));
+    REQUIRE(a->is_active());
+
+    b->buffer_put(key.data(), key.size(), v1.data(), v1.size());
+    REQUIRE(b->commit(&thd, true) == 0);
+
+    a->buffer_put(key.data(), key.size(), v1.data(), v1.size());
+    REQUIRE(a->commit(&thd, true) == HA_ERR_LOCK_DEADLOCK);
+  }
+
+  SECTION("read-only statement releases the snapshot at commit") {
+    bytecask::Bytes out;
+    REQUIRE(a->get(key.data(), key.size(), out) == 1);
+    REQUIRE(a->commit(&thd, true) == 0);
+    REQUIRE_FALSE(a->is_active());
+  }
+}
+
+// =========================================================================
 // Deferred INSERT dup-check (P3): commit-time ensure_absent conflict
 // =========================================================================
 

--- a/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
+++ b/bytecaskdb-mariadb-plugin/tests/unit/mariadb_txn_test.cpp
@@ -16,6 +16,7 @@
 #include "bytecask.hpp"
 #include "bytecaskdb_txn.h"
 #include "catalog.h"
+#include "key_encoding.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -647,4 +648,88 @@ TEST_CASE_METHOD(MariaDBTxnFixture,
   }
 
   g_stub_thd_options = 0;
+}
+
+// =========================================================================
+// MergeIterator direction (BC-250): buffered writes merged in scan order
+// =========================================================================
+
+namespace {
+
+// Row key for table `tid` with a one-byte suffix: [0x02 | tid BE4 | c].
+std::vector<uint8_t> row_key(uint32_t tid, uint8_t c) {
+  auto k = table_id_prefix(tid);
+  k.push_back(c);
+  return k;
+}
+
+std::vector<uint8_t> collect_keys(MariaDBTxn::MergeIterator &it) {
+  std::vector<uint8_t> out;
+  for (; it.valid(); it.next()) {
+    out.push_back(it.key_data()[it.key_len() - 1]);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(MariaDBTxnFixture,
+                 "MariaDBTxn MergeIterator honours scan direction",
+                 "[txn][merge][reverse]") {
+  constexpr uint32_t kTid = 42;
+  auto v = make_value("v");
+  THD thd{};
+
+  // Committed rows: 1, 3, 5, 7. Another table's row must never appear.
+  {
+    auto seed = create_txn();
+    for (uint8_t c : {1, 3, 5, 7}) {
+      auto k = row_key(kTid, c);
+      seed->buffer_put(k.data(), k.size(), v.data(), v.size());
+    }
+    auto other = row_key(kTid + 1, 0);
+    seed->buffer_put(other.data(), other.size(), v.data(), v.size());
+    REQUIRE(seed->commit(&thd, true) == 0);
+  }
+
+  auto txn = create_txn();
+  // Buffered: insert 2 and 8, delete 5, overwrite 3.
+  for (uint8_t c : {2, 8, 3}) {
+    auto k = row_key(kTid, c);
+    txn->buffer_put(k.data(), k.size(), v.data(), v.size());
+  }
+  {
+    auto k = row_key(kTid, 5);
+    txn->buffer_del(k.data(), k.size());
+  }
+
+  auto lo = table_id_prefix(kTid);
+  auto hi = table_id_upper_bound(kTid);
+
+  SECTION("forward scan is ascending with buffer merged") {
+    auto it = txn->iter_prefix(lo.data(), lo.size(), hi.data(), hi.size(), kTid);
+    REQUIRE(collect_keys(*it) == std::vector<uint8_t>{1, 2, 3, 7, 8});
+  }
+
+  SECTION("reverse scan is descending with buffer merged") {
+    auto it = txn->riter_prefix(hi.data(), hi.size(), lo.data(), lo.size(), kTid);
+    REQUIRE(collect_keys(*it) == std::vector<uint8_t>{8, 7, 3, 2, 1});
+  }
+
+  SECTION("reverse scan from a mid-range bound") {
+    auto mid = row_key(kTid, 4);
+    auto it = txn->riter_prefix(mid.data(), mid.size(), lo.data(), lo.size(), kTid);
+    REQUIRE(collect_keys(*it) == std::vector<uint8_t>{3, 2, 1});
+  }
+
+  SECTION("reverse scan when every buffered key is above the bound") {
+    // Only buffered keys 2, 3, 8 exist for this table; bound below all of
+    // them must not surface any of them.
+    auto txn2 = create_txn();
+    auto k = row_key(kTid, 9);
+    txn2->buffer_put(k.data(), k.size(), v.data(), v.size());
+    auto bound = row_key(kTid, 4);
+    auto it = txn2->riter_prefix(bound.data(), bound.size(), lo.data(), lo.size(), kTid);
+    REQUIRE(collect_keys(*it) == std::vector<uint8_t>{3, 1});
+  }
 }

--- a/bytecaskdb/radix_tree.cppm
+++ b/bytecaskdb/radix_tree.cppm
@@ -2580,10 +2580,10 @@ private:
     stack_.reserve(16);
     if (!root)
       return;
-    auto at_target = seek(root, target);
+    auto pos = seek(root, target);
     if (stack_.empty())
       return;
-    if (at_target && stack_.back().node->has_value())
+    if (pos.at_node && stack_.back().node->has_value())
       return;
     advance();
   }
@@ -2641,8 +2641,19 @@ private:
     }
   }
 
+  // Where seek() left the cursor. `at_node`: the top frame's node is the
+  // first node in key order whose key is >= target (child_idx 0, so the
+  // node itself is visited before its children). `exact`: that node's key
+  // equals target byte for byte. `exact` implies `at_node`; `at_node`
+  // without `exact` means the node's key is strictly greater than target
+  // (target ended inside the node's prefix, or diverged below it).
+  struct SeekPos {
+    bool at_node{false};
+    bool exact{false};
+  };
+
   auto seek(const IntrusivePtr<Node<V>> &root,
-            std::span<const std::byte> target) -> bool {
+            std::span<const std::byte> target) -> SeekPos {
     auto remaining = target;
     auto cur = root;
 
@@ -2654,21 +2665,21 @@ private:
       if (cpl < prefix_span.size() && cpl < remaining.size()) {
         if (prefix_span[cpl] > remaining[cpl]) {
           stack_.push_back({cur, 0});
-          return true;
+          return {.at_node = true, .exact = false};
         }
-        return false;
+        return {};
       }
 
       if (cpl < prefix_span.size()) {
         stack_.push_back({cur, 0});
-        return true;
+        return {.at_node = true, .exact = false};
       }
 
       remaining = remaining.subspan(cpl);
 
       if (remaining.empty()) {
         stack_.push_back({cur, 0});
-        return true;
+        return {.at_node = true, .exact = true};
       }
 
       auto target_byte = remaining[0];
@@ -2682,7 +2693,7 @@ private:
 
         if (!slot || slot->transition > target_byte) {
           stack_.push_back({cur, ordinal});
-          return false;
+          return {};
         }
         if (slot->transition < target_byte)
           continue;
@@ -2693,7 +2704,7 @@ private:
         break;
       }
     }
-    return false;
+    return {};
   }
 
   friend class PersistentRadixTree<V>;
@@ -2734,24 +2745,25 @@ public:
       past_rend_ = true;
       return;
     }
-    // Seek to the first key >= upper using a forward iterator.
+    // Position a forward cursor at lower_bound(upper): the first value node
+    // with key >= upper. If that key is exactly upper, start there
+    // (inclusive). Otherwise the last key <= upper is one retreat before
+    // the lower bound. Only a byte-exact match may start inclusively — a
+    // node that seek() lands on because upper ended inside its prefix has
+    // a key strictly greater than upper and must not be yielded.
     ValueIterator<V> fwd;
     fwd.stack_.reserve(16);
-    auto at_target = fwd.seek(root_, upper);
-    if (fwd.stack_.empty()) {
-      // All keys < upper. Position at the rightmost.
-      cur_.push_node(root_);
-      cur_.stack_.back().child_idx = cur_.stack_.back().node->child_count();
-      cur_.descend_rightmost();
-    } else if (at_target && fwd.stack_.back().node->has_value()) {
-      // Exact match — start here (inclusive).
+    auto pos = fwd.seek(root_, upper);
+    const bool on_value = !fwd.stack_.empty() && pos.at_node &&
+                          fwd.stack_.back().node->has_value();
+    if (on_value && pos.exact) {
       cur_ = std::move(fwd);
     } else {
-      // fwd is at or past the target — advance to the next value node,
-      // then retreat to find the last value node <= upper.
-      fwd.advance();
+      if (!fwd.stack_.empty() && !on_value) {
+        fwd.advance();
+      }
       if (fwd.stack_.empty()) {
-        // No key >= upper with a value; position at rightmost.
+        // Every key is < upper: start at the rightmost value node.
         cur_.push_node(root_);
         cur_.stack_.back().child_idx = cur_.stack_.back().node->child_count();
         cur_.descend_rightmost();

--- a/tests/bytecask_test.cpp
+++ b/tests/bytecask_test.cpp
@@ -2630,6 +2630,53 @@ TEST_CASE("DB riter_from with nonexistent key starts at predecessor",
   CHECK(keys[1] == "a");
 }
 
+TEST_CASE("DB riter_from with a key that is a strict prefix of an existing "
+          "key starts at the predecessor",
+          "[bytecask]") {
+  TempDir td;
+  auto db = bytecask::DB::open(td.path / "db");
+
+  // "ab" is a strict prefix of "abc" and has no entry of its own; the
+  // reverse scan from "ab" must begin at "aa", never at "abc" (> "ab").
+  db.put({}, to_bytes("aa"), to_bytes("1"));
+  db.put({}, to_bytes("abc"), to_bytes("2"));
+  db.put({}, to_bytes("abd"), to_bytes("3"));
+
+  SECTION("entry iterator") {
+    std::vector<std::string> keys;
+    for (auto &entry : db.riter_from({}, to_bytes("ab"))) {
+      keys.push_back(to_string(entry.key));
+    }
+    REQUIRE(keys == std::vector<std::string>{"aa"});
+  }
+
+  SECTION("key iterator agrees") {
+    std::vector<std::string> keys;
+    for (auto &k : db.rkeys_from({}, to_bytes("ab"))) {
+      keys.push_back(to_string(k));
+    }
+    REQUIRE(keys == std::vector<std::string>{"aa"});
+  }
+
+  SECTION("bound that diverges below a node prefix") {
+    // "ab\x00" < "abc": lower bound is "abc", predecessor is "aa".
+    std::vector<std::string> keys;
+    for (auto &entry : db.riter_from({}, to_bytes(std::string_view{"ab\0", 3}))) {
+      keys.push_back(to_string(entry.key));
+    }
+    REQUIRE(keys == std::vector<std::string>{"aa"});
+  }
+
+  SECTION("exact key present still starts inclusively") {
+    db.put({}, to_bytes("ab"), to_bytes("4"));
+    std::vector<std::string> keys;
+    for (auto &entry : db.riter_from({}, to_bytes("ab"))) {
+      keys.push_back(to_string(entry.key));
+    }
+    REQUIRE(keys == std::vector<std::string>{"ab", "aa"});
+  }
+}
+
 TEST_CASE("DB rkeys_from returns all keys in descending order",
           "[bytecask]") {
   TempDir td;


### PR DESCRIPTION
## Summary

Correctness fixes for the MariaDB plugin found while reviewing it ahead of a long steady-state benchmark against InnoDB. The plan and the reasoning are in `bytecaskdb-mariadb-plugin/docs/steady_state_plan.md` (first commit). One commit per item; the engine fix is its own commit.

Several of these were returning wrong results silently on `main`, not just slowly.

## Fixes

**Transactions**
- **Lost updates in autocommit (BC-248).** `get()`/`exists()` read the live DB and the OCC snapshot was taken later by the first write, so `UPDATE t SET v = v + 1` could overwrite a concurrent commit. The snapshot is now pinned on the first read; the late writer gets 1213.
- **Statement rollback discarded the whole transaction (BC-249).** A failed statement after `BEGIN` cleared every earlier statement and `COMMIT` returned success as a no-op. Statement rollback now rewinds to a mark recorded at statement start, restoring row counters too.
- **Savepoints drifted the row counters.** `ROLLBACK TO SAVEPOINT` now restores them.

**Scans**
- **Reverse scans merged buffered writes forward (BC-250).** Descending scans inside a transaction returned uncommitted rows out of order; `HA_READ_BEFORE_KEY`/`HA_READ_KEY_OR_PREV` went down a forward iterator; `WHERE a = ?` on a composite PK found nothing; `PREFIX_LAST` double-transformed the key and padded with the encoding of `-1`. `index_read_map` now has one shared positioning path driven by a per-flag mode table, padding in transformed space.
- **Engine: `riter_from` started above its bound** when the bound was a strict prefix of an existing key (`rkeys_from` was fine). In the plugin this made a descending PK scan on a table whose neighbouring table id had rows lose its entire snapshot side. Fixed in `ReverseValueIterator`; engine test added.
- **`records_in_range` returned a constant tenth of the table.** Selective ranges are now counted exactly (up to 1024 keys, including buffered rows); the merge iterator's bound check also ignored any bound longer than the keys.

**Deferred INSERT (follow-ups to #29)**
- **Error code regression.** #29 reported duplicates as 1586; clients and ORMs check 1062. Now reported through the server's `print_keydup_error` with the key value, code 1062. Caught by the functional suite.
- **Triggers.** A trigger's insert into a second table entered deferred mode after the outer table had taken a snapshot, leaving the transaction half in each mode; the fallback message path then crashed the server (the plugin's view of THD without `WITH_WSREP` does not match the server's layout). Tables with triggers take the eager path, deferred mode can only start on a stateless transaction, and the fallback uses a literal format.

**Other**
- `catalog_lookup_meta` returned a pointer into a mutex-guarded map; replaced with a copy-under-lock API, DML paths use the handler's cached index list.
- `HTON_SUPPORTS_FOREIGN_KEYS` dropped (it changed nothing visible on 10.11; FK clauses are still recorded, never enforced). README gains a "Differences from InnoDB" section; the code guide is corrected where it had drifted.
- Functional runner supports `expected: discard`, which one existing case already used.

## Testing

On the final tree:
- Engine: 1,447 cases (`~[model]~[stress]~[slow]~[resume]~[degraded]`) and the 4 `[model]` recovery cases pass.
- Plugin unit + proof: 237 pass.
- Plugin functional (live `mariadbd`): 214 pass. First fully green run of that suite; `main` had two failing cases.

New tests: 5 unit cases, 3 functional Python tests, 9 YAML cases, 1 engine case. Each fix's unit test was checked to fail without the fix where practical.
