### PR TITLE
Run the MariaDB plugin test suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
-# Main CI pipeline: build, test, sanitizers, and fuzz testing (Linux only).
+# Main CI pipeline: build, test, sanitizers, fuzz testing, and the MariaDB
+# plugin suites (Linux only).
 # macOS coverage is handled by build-wheels.yml.
 
 name: CI
@@ -103,6 +104,107 @@ jobs:
           report_type: test_results
           flags: cpp
           name: bytecask-cpp-tests
+          slug: gustavoamigo/bytecaskdb
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          use_oidc: true
+
+  # ---------------------------------------------------------------------------
+  # MariaDB storage engine plugin: unit + proof tests (Catch2/ctest) and the
+  # functional suite against a live mariadbd (pytest).
+  # ---------------------------------------------------------------------------
+  mariadb-plugin:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:43
+    permissions:
+      contents: read
+      checks: write
+      id-token: write
+    env:
+      BYTECASK_MARCH: x86-64-v3
+      XMAKE_ROOT: "y"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+            clang llvm llvm-devel lld \
+            libcxx libcxx-devel \
+            gcc gcc-c++ cmake \
+            xmake \
+            python3-pip python3-devel \
+            git ninja-build \
+            mariadb mariadb-server mariadb-devel \
+            google-crc32c-devel
+          pip3 install nanobind
+          pip3 install -r bytecaskdb-mariadb-plugin/tests/functional/requirements.txt
+
+      - name: Configure xmake
+        run: |
+          RESOURCE_DIR=$(clang --print-resource-dir)
+          xmake f --toolchain=clang \
+            --cxflags="-resource-dir=${RESOURCE_DIR}" \
+            -y
+
+      - name: Build engine static libraries
+        run: |
+          xmake build bytecask
+          xmake build bytecask_testing
+
+      - name: Build plugin and test binaries
+        run: |
+          cmake -S bytecaskdb-mariadb-plugin -B bytecaskdb-mariadb-plugin/build \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build bytecaskdb-mariadb-plugin/build --parallel
+
+      - name: Run unit and proof tests
+        run: |
+          mkdir -p test-results
+          cd bytecaskdb-mariadb-plugin/build
+          ctest --output-on-failure \
+            --output-junit "${GITHUB_WORKSPACE}/test-results/mariadb_plugin_ctest.xml"
+
+      - name: Run functional tests against mariadbd
+        run: |
+          python3 -m pytest bytecaskdb-mariadb-plugin/tests/functional \
+            -v -p no:cacheprovider \
+            --junitxml=test-results/mariadb_plugin_functional.xml
+
+      - name: Upload mariadbd log on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mariadb-plugin-server-log
+          path: .mariadb_functional_test/error.log
+          if-no-files-found: ignore
+
+      - name: Publish test results in GitHub Checks
+        if: ${{ always() && !cancelled() }}
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: test-results/mariadb_plugin_*.xml
+          check_name: MariaDB Plugin Test Results
+          comment_mode: off
+
+      - name: Upload JUnit reports artifact
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-mariadb-plugin-results
+          path: test-results/mariadb_plugin_*.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ always() && !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: |
+            ./test-results/mariadb_plugin_ctest.xml
+            ./test-results/mariadb_plugin_functional.xml
+          report_type: test_results
+          flags: mariadb-plugin
+          name: mariadb-plugin-tests
           slug: gustavoamigo/bytecaskdb
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/bytecaskdb-mariadb-plugin/tests/functional/conftest.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/conftest.py
@@ -71,11 +71,15 @@ class MariaDBServer:
                 f"Plugin not found: {self.plugin_dir}/ha_bytecaskdb.so — run cmake --build first"
             )
 
+        # mariadbd refuses to run as root unless told to; CI containers are root.
+        as_root = ["--user=root"] if os.geteuid() == 0 else []
+
         subprocess.run(
             [
                 "mariadb-install-db",
                 f"--datadir={self.data_dir}",
                 "--auth-root-authentication-method=normal",
+                *as_root,
             ],
             check=True,
             stdout=subprocess.DEVNULL,
@@ -96,6 +100,7 @@ class MariaDBServer:
                 f"--plugin-dir={self.plugin_dir}",
                 f"--plugin-load-add=bytecaskdb=ha_bytecaskdb.so",
                 f"--log-error={self.log_file}",
+                *as_root,
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/bytecaskdb-mariadb-plugin/tests/functional/conftest.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/conftest.py
@@ -49,6 +49,11 @@ def _symlink_provider_plugins(plugin_dir):
         break
 
 
+def root_user_args():
+    """mariadbd refuses to run as root unless told to; CI containers are root."""
+    return ["--user=root"] if os.geteuid() == 0 else []
+
+
 class MariaDBServer:
     def __init__(self):
         self.root = _find_bytecask_root()
@@ -71,8 +76,7 @@ class MariaDBServer:
                 f"Plugin not found: {self.plugin_dir}/ha_bytecaskdb.so — run cmake --build first"
             )
 
-        # mariadbd refuses to run as root unless told to; CI containers are root.
-        as_root = ["--user=root"] if os.geteuid() == 0 else []
+        as_root = root_user_args()
 
         subprocess.run(
             [

--- a/bytecaskdb-mariadb-plugin/tests/functional/test_backup.py
+++ b/bytecaskdb-mariadb-plugin/tests/functional/test_backup.py
@@ -15,6 +15,8 @@ import time
 import pytest
 import pymysql
 
+from conftest import root_user_args
+
 
 # ---------------------------------------------------------------------------
 # Helpers (session-scoped server tests)
@@ -96,7 +98,7 @@ class _StandaloneMariaDB:
         os.makedirs(os.path.join(self.test_dir, "tmp"), exist_ok=True)
         subprocess.run(
             ["mariadb-install-db", f"--datadir={self.data_dir}",
-             "--auth-root-authentication-method=normal"],
+             "--auth-root-authentication-method=normal", *root_user_args()],
             check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         _symlink_provider_plugins(self.plugin_dir)
@@ -113,6 +115,7 @@ class _StandaloneMariaDB:
             f"--plugin-dir={self.plugin_dir}",
             f"--plugin-load-add=bytecaskdb=ha_bytecaskdb.so",
             f"--log-error={self.log_file}",
+            *root_user_args(),
         ]
         if self.skip_grant_tables:
             cmd.append("--skip-grant-tables")


### PR DESCRIPTION
## Summary

Adds a `mariadb-plugin` job to `ci.yml`. Until now CI built and tested only the engine, so a plugin PR (such as #31) had green checks that never exercised the plugin.

The job, on the same `fedora:43` container as the other jobs:
1. builds `libbytecask.a` and `libbytecask_testing.a` with xmake (clang, as elsewhere in CI);
2. builds the plugin and its Catch2 targets with CMake against `mariadb-devel`;
3. runs the unit and proof tests via `ctest`;
4. runs the functional suite (`pytest tests/functional`) against a `mariadbd` the fixture provisions itself.

Both suites emit JUnit, published as a separate check ("MariaDB Plugin Test Results"), uploaded as an artifact, and sent to Codecov Test Analytics under the `mariadb-plugin` flag. The server error log is uploaded if the job fails.

One fixture change: `conftest.py` passes `--user=root` to `mariadb-install-db` and `mariadbd` when running as root, which is the case inside the CI container and which the server otherwise refuses. Verified locally under `sudo`.

The job itself has not been rehearsed locally; this PR is the rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
